### PR TITLE
feat: deploy all contracts with less config params for ContentSignNFT

### DIFF
--- a/contracts/contracts/contentsign/ContentSignNFT.sol
+++ b/contracts/contracts/contentsign/ContentSignNFT.sol
@@ -12,7 +12,7 @@ contract ContentSignNFT is ERC721, ERC721URIStorage, AccessControl {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     uint256 private _nextTokenId;
 
-    constructor(string memory tokenName, string memory tokenSymbol, address defaultAdmin, address minter) ERC721(tokenName, tokenSymbol) {
+    constructor(address defaultAdmin, address minter) ERC721("ContentSign", "CSN") {
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
         _grantRole(MINTER_ROLE, minter);
     }

--- a/contracts/contracts/contentsign/ContentSignNFTFactory.sol
+++ b/contracts/contracts/contentsign/ContentSignNFTFactory.sol
@@ -10,12 +10,10 @@ import "./ContentSignNFT.sol";
 contract ContentSignNFTFactory {
     function deployContentSignNFT(
         bytes32 _salt,
-        string memory _tokenName,
-        string memory _tokenSymbol,
         address _defaultAdmin,
         address _defaultMinter
     ) external returns (address) {
-        ContentSignNFT nft = new ContentSignNFT{salt: _salt}(_tokenName, _tokenSymbol, _defaultAdmin, _defaultMinter);
+        ContentSignNFT nft = new ContentSignNFT{salt: _salt}(_defaultAdmin, _defaultMinter);
         return address(nft);
     }
 }

--- a/contracts/deploy/deploy.ts
+++ b/contracts/deploy/deploy.ts
@@ -2,4 +2,6 @@ import { deployContract, getGovernance } from "./utils";
 
 export default async function() {
     await deployContract("NODL", [getGovernance(), getGovernance()]);
+    await deployContract("ContentSignNFT", [getGovernance(), getGovernance()]);
+    await deployContract("WhitelistPaymaster", [getGovernance(), getGovernance(), []]);
 }

--- a/contracts/test/contentsign/ContentSignNFT.test.ts
+++ b/contracts/test/contentsign/ContentSignNFT.test.ts
@@ -11,7 +11,7 @@ describe("ContentSignNFT", function () {
     ownerWallet = getWallet(LOCAL_RICH_WALLETS[0].privateKey);
     userWallet = getWallet(LOCAL_RICH_WALLETS[1].privateKey);
 
-    tokenContract = await deployContract("ContentSignNFT", ["Mock NFT", "MFT", ownerWallet.address, ownerWallet.address], { wallet: ownerWallet, silent: true, skipChecks: true });
+    tokenContract = await deployContract("ContentSignNFT", [ownerWallet.address, ownerWallet.address], { wallet: ownerWallet, silent: true, skipChecks: true });
   });
 
   it("Should mint token", async function () {

--- a/contracts/test/contentsign/ContentSignNFTFactory.test.ts
+++ b/contracts/test/contentsign/ContentSignNFTFactory.test.ts
@@ -17,7 +17,7 @@ describe("ContentSignNFTFactory", function () {
     it("Should deploy contract", async function () {
         const salt = ethers.ZeroHash;
 
-        const tx = await factory.deployContentSignNFT(salt, "Mock NFT", "MFT", wallet.address, wallet.address);
+        const tx = await factory.deployContentSignNFT(salt, wallet.address, wallet.address);
         await tx.wait();
 
         const deployer = new Deployer(hre, wallet);
@@ -28,15 +28,15 @@ describe("ContentSignNFTFactory", function () {
             await factory.getAddress(),
             utils.hashBytecode(artifact.bytecode),
             salt,
-            abiCoder.encode(["string", "string", "address", "address"], ["Mock NFT", "MFT", wallet.address, wallet.address])
+            abiCoder.encode(["address", "address"], [wallet.address, wallet.address])
         );
 
         const nft = new Contract(contractAddress, artifact.abi, wallet);
         const name = await nft.name();
         const symbol = await nft.symbol();
 
-        expect(name).to.equal("Mock NFT");
-        expect(symbol).to.equal("MFT");
+        expect(name).to.equal("ContentSign");
+        expect(symbol).to.equal("CSN");
         expect(await nft.hasRole(await nft.DEFAULT_ADMIN_ROLE(), wallet.address)).to.equal(true);
         expect(await nft.hasRole(await nft.MINTER_ROLE(), wallet.address)).to.equal(true);
     });


### PR DESCRIPTION
We have 3 main contracts as of now: NODL, WhitelistPaymaster, ContentSignNFT. Let them all be deployed with the following command:
`cd contracts; yarn compile && yarn deploy`

@ETeissonniere Because we have given a very specific name to our NFT contract, I thought it would be good to let it also assign the name and symbol for such contracts as "ContentSign", "CSN". This reduces the config parameters.