### PR TITLE
replace modifiers with expressive function calls

### DIFF
--- a/src/NODL.sol
+++ b/src/NODL.sol
@@ -14,7 +14,9 @@ contract NODL is ERC20Burnable, AccessControl {
         _grantRole(MINTER_ROLE, msg.sender);
     }
 
-    function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
+    function mint(address to, uint256 amount) public {
+        _checkRole(MINTER_ROLE);
+
         _mint(to, amount);
     }
 }

--- a/src/contentsign/ContentSignNFT.sol
+++ b/src/contentsign/ContentSignNFT.sol
@@ -15,18 +15,13 @@ contract ContentSignNFT is ERC721, ERC721URIStorage {
 
     error UserIsNotWhitelisted();
 
-    modifier onlyWhitelised() {
-        if (!whitelistPaymaster.isWhitelistedUser(msg.sender)) {
-            revert UserIsNotWhitelisted();
-        }
-        _;
-    }
-
     constructor(string memory name, string memory symbol, WhitelistPaymaster whitelist) ERC721(name, symbol) {
         whitelistPaymaster = whitelist;
     }
 
-    function safeMint(address to, string memory uri) public onlyWhitelised {
+    function safeMint(address to, string memory uri) public {
+        _mustBeWhitelisted();
+
         uint256 tokenId = nextTokenId++;
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
@@ -38,5 +33,11 @@ contract ContentSignNFT is ERC721, ERC721URIStorage {
 
     function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721URIStorage) returns (bool) {
         return super.supportsInterface(interfaceId);
+    }
+
+    function _mustBeWhitelisted() internal view {
+        if (!whitelistPaymaster.isWhitelistedUser(msg.sender)) {
+            revert UserIsNotWhitelisted();
+        }
     }
 }

--- a/src/paymasters/Erc20Paymaster.sol
+++ b/src/paymasters/Erc20Paymaster.sol
@@ -28,8 +28,16 @@ contract Erc20Paymaster is BasePaymaster {
         feePrice = initialFeePrice;
     }
 
-    function updateFeePrice(uint256 newFeePrice) public onlyRole(PRICE_ORACLE_ROLE) {
+    function updateFeePrice(uint256 newFeePrice) public {
+        _checkRole(PRICE_ORACLE_ROLE);
+
         feePrice = newFeePrice;
+    }
+
+    function withdrawTokens(address to, uint256 amount) public {
+        _checkRole(WITHDRAWER_ROLE);
+
+        allowedToken.safeTransfer(to, amount);
     }
 
     function _validateAndPayGeneralFlow(address, /* from */ address, /* to */ uint256 /* requiredETH */ )
@@ -66,9 +74,5 @@ contract Erc20Paymaster is BasePaymaster {
         }
 
         allowedToken.safeTransferFrom(userAddress, thisAddress, requiredToken);
-    }
-
-    function withdrawTokens(address to, uint256 amount) public onlyRole(WITHDRAWER_ROLE) {
-        allowedToken.safeTransfer(to, amount);
     }
 }

--- a/src/paymasters/WhitelistPaymaster.sol
+++ b/src/paymasters/WhitelistPaymaster.sol
@@ -18,26 +18,31 @@ contract WhitelistPaymaster is BasePaymaster {
         _grantRole(WHITELIST_ADMIN_ROLE, msg.sender);
     }
 
-    function addWhitelistedContracts(address[] calldata whitelistedContracts) external onlyRole(WHITELIST_ADMIN_ROLE) {
+    function addWhitelistedContracts(address[] calldata whitelistedContracts) external {
+        _checkRole(WHITELIST_ADMIN_ROLE);
+
         _setContractWhitelist(whitelistedContracts);
     }
 
-    function removeWhitelistedContracts(address[] calldata whitelistedContracts)
-        external
-        onlyRole(WHITELIST_ADMIN_ROLE)
-    {
+    function removeWhitelistedContracts(address[] calldata whitelistedContracts) external {
+        _checkRole(WHITELIST_ADMIN_ROLE);
+
         for (uint256 i = 0; i < whitelistedContracts.length; i++) {
             isWhitelistedContract[whitelistedContracts[i]] = false;
         }
     }
 
-    function addWhitelistedUsers(address[] calldata users) external onlyRole(WHITELIST_ADMIN_ROLE) {
+    function addWhitelistedUsers(address[] calldata users) external {
+        _checkRole(WHITELIST_ADMIN_ROLE);
+
         for (uint256 i = 0; i < users.length; i++) {
             isWhitelistedUser[users[i]] = true;
         }
     }
 
-    function removeWhitelistedUsers(address[] calldata users) external onlyRole(WHITELIST_ADMIN_ROLE) {
+    function removeWhitelistedUsers(address[] calldata users) external {
+        _checkRole(WHITELIST_ADMIN_ROLE);
+
         for (uint256 i = 0; i < users.length; i++) {
             isWhitelistedUser[users[i]] = false;
         }


### PR DESCRIPTION
1. Adjust with the style of the `NODLMigration` contract
2. Modifiers make it harder to notice what is happening with a function call VS a more expressive syntax