### PR TITLE
feat(NODLMigration): closing an already closed proposal is noop

### DIFF
--- a/test/dot-migration/NODLMigration.t.sol
+++ b/test/dot-migration/NODLMigration.t.sol
@@ -134,7 +134,8 @@ contract NODLMigrationTest is Test {
 
         migration.withdraw(0x0);
 
-        vm.expectRevert(abi.encodeWithSelector(NODLMigration.AlreadyExecuted.selector, 0x0));
+        vm.expectEmit();
+        emit NODLMigration.AlreadyWithdrawn(0x0);
         migration.withdraw(0x0);
     }
 


### PR DESCRIPTION
If a closer tries to close an already closed proposal and this returns success, it can proceed safely to subsequent operation supposing it has made the change itself