### PR TITLE
feat(Rewards): add mintBatchReward

### DIFF
--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -133,7 +133,6 @@ contract Rewards is AccessControl, EIP712 {
      * @dev Event emitted when a reward is minted.
      */
     event Minted(address indexed recipient, uint256 amount, uint256 totalRewardsClaimed);
-
     /**
      * @dev Emitted when a batch reward is minted.
      * @param batchSum The sum of rewards in the batch.
@@ -308,7 +307,11 @@ contract Rewards is AccessControl, EIP712 {
      * @return The sum of all amounts in the batch.
      */
     function _batchSum(BatchReward memory batch) internal pure returns (uint256) {
-        // Function implementation...
+        uint256 sum = 0;
+        for (uint256 i = 0; i < batch.amounts.length; i++) {
+            sum += batch.amounts[i];
+        }
+        return sum;
     }
 
     /**

--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -185,16 +185,13 @@ contract Rewards is AccessControl, EIP712 {
      */
     function mintReward(Reward memory reward, bytes memory signature) external {
         _mustBeExpectedSequence(reward.recipient, reward.sequence);
-
         _mustBeFromAuthorizedOracle(digestReward(reward), signature);
 
         _checkedUpdateQuota();
-
         _checkedUpdateClaimed(reward.amount);
 
         // Safe to increment the sequence after checking this is the expected number (no overflow for the age of universe even with 1000 reward claims per second)
         sequences[reward.recipient] = reward.sequence + 1;
-
         nodl.mint(reward.recipient, reward.amount);
 
         emit Minted(reward.recipient, reward.amount, claimed);
@@ -207,15 +204,11 @@ contract Rewards is AccessControl, EIP712 {
      */
     function mintBatchReward(BatchReward memory batch, bytes memory signature) external {
         _mustBeValidBatchStructure(batch);
-
         _mustBeExpectedBatchSequence(batch.sequence);
-
         _mustBeFromAuthorizedOracle(digestBatchReward(batch), signature);
 
         _checkedUpdateQuota();
-
         uint256 batchSum = _batchSum(batch);
-
         _checkedUpdateClaimed(batchSum);
 
         // Safe to increment the sequence after checking this is the expected number (no overflow for the age of universe even with 1000 reward claims per second)

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -31,7 +31,7 @@ contract RewardsTest is Test {
 
     function testSetQuota() public {
         // Check initial quota
-        assertEq(rewards.rewardQuota(), 1000);
+        assertEq(rewards.quota(), 1000);
 
         address alice = address(2);
 
@@ -40,17 +40,17 @@ contract RewardsTest is Test {
 
         // Set the new quota
         vm.prank(alice);
-        rewards.setRewardQuota(2000);
+        rewards.setQuota(2000);
 
         // Check new quota
-        assertEq(rewards.rewardQuota(), 2000);
+        assertEq(rewards.quota(), 2000);
     }
 
     function testSetQuotaUnauthorized() public {
         address bob = address(3);
         vm.expectRevert_AccessControlUnauthorizedAccount(bob, rewards.DEFAULT_ADMIN_ROLE());
         vm.prank(bob);
-        rewards.setRewardQuota(2000);
+        rewards.setQuota(2000);
     }
 
     function testMintReward() public {
@@ -63,8 +63,8 @@ contract RewardsTest is Test {
 
         // Check balances and sequences
         assertEq(nodlToken.balanceOf(recipient), 100);
-        assertEq(rewards.rewardsClaimed(), 100);
-        assertEq(rewards.rewardSequences(recipient), 1);
+        assertEq(rewards.claimed(), 100);
+        assertEq(rewards.sequences(recipient), 1);
     }
 
     function testMintRewardQuotaExceeded() public {
@@ -73,7 +73,7 @@ contract RewardsTest is Test {
         bytes memory signature = createSignature(reward, oraclePrivateKey);
 
         // Expect the quota to be exceeded
-        vm.expectRevert(Rewards.RewardQuotaExceeded.selector);
+        vm.expectRevert(Rewards.QuotaExceeded.selector);
         rewards.mintReward(reward, signature);
     }
 
@@ -142,7 +142,7 @@ contract RewardsTest is Test {
         uint256 fourthRenewal = firstRenewal + 3 * RENEWAL_PERIOD;
         uint256 fifthRenewal = firstRenewal + 4 * RENEWAL_PERIOD;
 
-        assertEq(rewards.rewardsClaimed(), 100);
+        assertEq(rewards.claimed(), 100);
         assertEq(rewards.quotaRenewalTimestamp(), firstRenewal);
 
         vm.warp(fourthRenewal + 1 seconds);
@@ -151,7 +151,7 @@ contract RewardsTest is Test {
         signature = createSignature(reward, oraclePrivateKey);
         rewards.mintReward(reward, signature);
 
-        assertEq(rewards.rewardsClaimed(), 50);
+        assertEq(rewards.claimed(), 50);
         assertEq(rewards.quotaRenewalTimestamp(), fifthRenewal);
     }
 
@@ -175,7 +175,7 @@ contract RewardsTest is Test {
         signature = createSignature(reward, oraclePrivateKey);
         rewards.mintReward(reward, signature);
 
-        assertEq(rewards.rewardsClaimed(), 26);
+        assertEq(rewards.claimed(), 26);
     }
 
     function createSignature(Rewards.Reward memory reward, uint256 privateKey) internal view returns (bytes memory) {

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -254,7 +254,7 @@ contract RewardsTest is Test {
         bytes memory signature = createSignature(reward, oraclePrivateKey);
         rewards.mintReward(reward, signature);
 
-        uint256 firstRenewal = block.timestamp + RENEWAL_PERIOD;
+        uint256 firstRenewal = RENEWAL_PERIOD + 1; // `+ 1` comes from the expected initial value of block.timestamp
         uint256 fourthRenewal = firstRenewal + 3 * RENEWAL_PERIOD;
         uint256 fifthRenewal = firstRenewal + 4 * RENEWAL_PERIOD;
         uint256 sixthRenewal = firstRenewal + 5 * RENEWAL_PERIOD;
@@ -283,6 +283,7 @@ contract RewardsTest is Test {
         bytes memory batchSignature = createBatchSignature(rewardsBatch, oraclePrivateKey);
         rewards.mintBatchReward(rewardsBatch, batchSignature);
         assertEq(rewards.claimed(), 300);
+
         assertEq(rewards.quotaRenewalTimestamp(), sixthRenewal);
     }
 

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -29,7 +29,7 @@ contract RewardsTest is Test {
         nodlToken.grantRole(nodlToken.MINTER_ROLE(), address(rewards));
     }
 
-    function testSetQuota() public {
+    function test_setQuota() public {
         // Check initial quota
         assertEq(rewards.quota(), 1000);
 
@@ -46,14 +46,14 @@ contract RewardsTest is Test {
         assertEq(rewards.quota(), 2000);
     }
 
-    function testSetQuotaUnauthorized() public {
+    function test_setQuotaUnauthorized() public {
         address bob = address(3);
         vm.expectRevert_AccessControlUnauthorizedAccount(bob, rewards.DEFAULT_ADMIN_ROLE());
         vm.prank(bob);
         rewards.setQuota(2000);
     }
 
-    function testMintReward() public {
+    function test_mintReward() public {
         // Prepare the reward and signature
         Rewards.Reward memory reward = Rewards.Reward(recipient, 100, 0);
         bytes memory signature = createSignature(reward, oraclePrivateKey);
@@ -67,7 +67,7 @@ contract RewardsTest is Test {
         assertEq(rewards.sequences(recipient), 1);
     }
 
-    function testMintRewardQuotaExceeded() public {
+    function test_mintRewardQuotaExceeded() public {
         // Prepare the reward and signature
         Rewards.Reward memory reward = Rewards.Reward(recipient, 1100, 0);
         bytes memory signature = createSignature(reward, oraclePrivateKey);
@@ -77,7 +77,7 @@ contract RewardsTest is Test {
         rewards.mintReward(reward, signature);
     }
 
-    function testMintRewardUnauthorizedOracle() public {
+    function test_mintRewardUnauthorizedOracle() public {
         // Prepare the reward and signature with an unauthorized oracle
         Rewards.Reward memory reward = Rewards.Reward(recipient, 100, 0);
         bytes memory signature = createSignature(reward, 0xDEAD);
@@ -87,7 +87,7 @@ contract RewardsTest is Test {
         rewards.mintReward(reward, signature);
     }
 
-    function testMintRewardInvalidsequence() public {
+    function test_mintRewardInvalidsequence() public {
         // Prepare the reward and signature
         Rewards.Reward memory reward = Rewards.Reward(recipient, 100, 1); // Invalid sequence
         bytes memory signature = createSignature(reward, oraclePrivateKey);
@@ -97,7 +97,7 @@ contract RewardsTest is Test {
         rewards.mintReward(reward, signature);
     }
 
-    function testMintBatchReward() public {
+    function test_mintBatchReward() public {
         address[] memory recipients = new address[](2);
         uint256[] memory amounts = new uint256[](2);
 
@@ -120,7 +120,7 @@ contract RewardsTest is Test {
         assertEq(rewards.batchSequence(), 1);
     }
 
-    function testMintBatchRewardQuotaExceeded() public {
+    function test_mintBatchRewardQuotaExceeded() public {
         address[] memory recipients = new address[](2);
         uint256[] memory amounts = new uint256[](2);
 
@@ -137,7 +137,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(rewardsBatch, signature);
     }
 
-    function testMintBatchRewardUnauthorizedOracle() public {
+    function test_mintBatchRewardUnauthorizedOracle() public {
         address[] memory recipients = new address[](2);
         uint256[] memory amounts = new uint256[](2);
 
@@ -154,7 +154,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(rewardsBatch, signature);
     }
 
-    function testMintBatchRewardInvalidSequence() public {
+    function test_mintBatchRewardInvalidSequence() public {
         address[] memory recipients = new address[](2);
         uint256[] memory amounts = new uint256[](2);
 
@@ -171,7 +171,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(rewardsBatch, signature);
     }
 
-    function testMintBatchRewardInvalidStruct() public {
+    function test_mintBatchRewardInvalidStruct() public {
         address[] memory recipients = new address[](2);
         uint256[] memory amounts = new uint256[](1);
 
@@ -187,7 +187,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(rewardsBatch, signature);
     }
 
-    function testDigestReward() public {
+    function test_digestReward() public {
         bytes32 hashedEIP712DomainType =
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
         bytes32 hashedName = keccak256(bytes("rewards.depin.nodle"));
@@ -203,7 +203,7 @@ contract RewardsTest is Test {
         assertEq(rewards.digestReward(reward), digest);
     }
 
-    function testMintRewardInvalidDigest() public {
+    function test_mintRewardInvalidDigest() public {
         bytes32 hashedEIP712DomainType =
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
         bytes32 hashedName = keccak256(bytes("rewards.depin.nodle"));
@@ -223,7 +223,7 @@ contract RewardsTest is Test {
         rewards.mintReward(reward, signature);
     }
 
-    function testMintBatchRewardInvalidDigest() public {
+    function test_mintBatchRewardInvalidDigest() public {
         bytes32 hashedEIP712DomainType =
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
         bytes32 hashedName = keccak256(bytes("rewards.depin.nodle"));
@@ -249,7 +249,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(Rewards.BatchReward(recipients, amounts, 0), signature);
     }
 
-    function testRewardsClaimedResetsOnNewPeriod() public {
+    function test_rewardsClaimedResetsOnNewPeriod() public {
         Rewards.Reward memory reward = Rewards.Reward(recipient, 100, 0);
         bytes memory signature = createSignature(reward, oraclePrivateKey);
         rewards.mintReward(reward, signature);
@@ -287,7 +287,7 @@ contract RewardsTest is Test {
         assertEq(rewards.quotaRenewalTimestamp(), sixthRenewal);
     }
 
-    function testRewardsClaimedAccumulates() public {
+    function test_rewardsClaimedAccumulates() public {
         address user1 = address(11);
         address user2 = address(22);
         address user3 = address(33);


### PR DESCRIPTION
In this implementation I have defined the struct BatchReward as:
```
    struct BatchReward {
        address[] recipients;
        uint256[] amounts;
        uint256 sequence;
    }
```
assuming `recipients[i]` corresponds to `amounts[i]`. This means we expect `recipients.length == amounts.length`. That's why `mintBatchReward` needed to check this assumption. The reason I have gone for this design was to avoid using **nested types** which could make `digestReward` more complicated and costly. `digestReward` is needed for checking the signature.