### PR TITLE
feat(Rewards): add deploy script

### DIFF
--- a/script/DeployNodlMigration.sol
+++ b/script/DeployNodlMigration.sol
@@ -7,7 +7,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {NODL} from "../src/NODL.sol";
 import {NODLMigration} from "../src/bridge/NODLMigration.sol";
 
-contract DeployClick is Script {
+contract DeployNodlMigration is Script {
     address[] internal voters;
     address internal withdrawer;
 

--- a/script/DeployRewards.sol
+++ b/script/DeployRewards.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity 0.8.23;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {NODL} from "../src/NODL.sol";
+import {Rewards} from "../src/Rewards.sol";
+
+contract DeployRewards is Script {
+    address internal nodlAddress;
+    address internal oracleAddress;
+    uint256 internal rewardQuotaPerPeriod;
+    uint256 internal rewardPeriod;
+    uint256 internal batchSubmitterIncentive; // in percentage of total rewards in a batch. 1 = 1%
+
+    function setUp() public {
+        nodlAddress = vm.envOr("N_TOKEN_ADDR", address(0));
+        oracleAddress = vm.envAddress("N_REWARDS_ORACLE_ADDR");
+        rewardQuotaPerPeriod = vm.envUint("N_REWARDS_QUOTA");
+        rewardPeriod = vm.envUint("N_REWARDS_PERIOD");
+        batchSubmitterIncentive = vm.envUint("N_REWARDS_SUBMITTER_INCENTIVE");
+    }
+
+    function run() public {
+        vm.startBroadcast();
+
+        NODL nodl;
+        if (nodlAddress == address(0)) {
+            nodl = new NODL();
+            nodlAddress = address(nodl);
+            console.log("Deployed NODL at %s", nodlAddress);
+        } else {
+            nodl = NODL(nodlAddress);
+        }
+
+        Rewards rewards = new Rewards(nodl, rewardQuotaPerPeriod, rewardPeriod, oracleAddress, batchSubmitterIncentive);
+        address rewardsAddress = address(rewards);
+
+        nodl.grantRole(nodl.MINTER_ROLE(), rewardsAddress);
+
+        vm.stopBroadcast();
+
+        console.log("Deployed Rewards at %s", rewardsAddress);
+    }
+}

--- a/script/DeployRewards.sol
+++ b/script/DeployRewards.sol
@@ -24,19 +24,15 @@ contract DeployRewards is Script {
 
     function run() public {
         vm.startBroadcast();
-
-        NODL nodl;
         if (nodlAddress == address(0)) {
-            nodl = new NODL();
-            nodlAddress = address(nodl);
+            NODL token = new NODL();
+            nodlAddress = address(token);
             console.log("Deployed NODL at %s", nodlAddress);
-        } else {
-            nodl = NODL(nodlAddress);
         }
 
+        NODL nodl = NODL(nodlAddress);
         Rewards rewards = new Rewards(nodl, rewardQuotaPerPeriod, rewardPeriod, oracleAddress, batchSubmitterIncentive);
         address rewardsAddress = address(rewards);
-
         nodl.grantRole(nodl.MINTER_ROLE(), rewardsAddress);
 
         vm.stopBroadcast();


### PR DESCRIPTION
NOTE 1: The forge script cannot proceed to successful deployment and hangs on:
```
Script ran successfully.

== Logs ==
  Deployed Rewards at 0x19610AF1045b349acEAE83c6239a5B13e567D612

## Setting up 1 EVM.

==========================

Chain 300

Estimated gas price: 3.05 gwei

Estimated total gas used for script: 772607094

Estimated amount required: 2.3564516367 ETH

==========================

###
Finding wallets for all the necessary addresses...
##
Sending transactions [0 - 1].
⠉ [00:00:01] [####################################################################################################################] 2/2 txes (0.0s)
Transactions saved to: /workspaces/rollup/broadcast/DeployRewards.sol/300/run-latest.json

Sensitive values saved to: /workspaces/rollup/cache/DeployRewards.sol/300/run-latest.json

##
Waiting for receipts.
⠁ [00:00:00] [----------------------------------------------------------------------------------------------------------------] 0/2 receipts (0.0s
```
NOTE 2: This PR contains a trivial renaming side effect for another script