### PR TITLE
freeze forge in devcontainer to known good commit

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,8 +33,10 @@ RUN sudo apt update && \
 
 RUN yarn global add zksync-cli && yarn global add @graphprotocol/graph-cli
 
+ARG KNOWN_GOOD_FORGE_COMMIT=f505a536a8f6ddae2b8618a701f66c047b1a2b0c
 RUN git clone https://github.com/matter-labs/foundry-zksync.git /tmp/foundry-zksync && \
     cd /tmp/foundry-zksync && \
+    git checkout ${KNOWN_GOOD_FORGE_COMMIT} && \
     cargo install --path ./crates/forge --profile local --force --locked && \
     cargo install --path ./crates/cast --profile local --force --locked && \
     rm -rf /tmp/foundry-zksync

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ RUN sudo apt update && \
 
 RUN yarn global add zksync-cli && yarn global add @graphprotocol/graph-cli
 
-ARG KNOWN_GOOD_FORGE_COMMIT=f505a536a8f6ddae2b8618a701f66c047b1a2b0c
+ARG KNOWN_GOOD_FORGE_COMMIT=33b81acf8688f8cc1fc839b7e4a07ec58b347cb4
 RUN git clone https://github.com/matter-labs/foundry-zksync.git /tmp/foundry-zksync && \
     cd /tmp/foundry-zksync && \
     git checkout ${KNOWN_GOOD_FORGE_COMMIT} && \


### PR DESCRIPTION
Build from `dev` every week is no longer the best idea as it introduces a number of bugs and breaking changes which hurts productivity and determinism for the team. So far we have had good results with the version under commit `33b81acf8688f8cc1fc839b7e4a07ec58b347cb4` and I suggest we stick to it until we have a strong reasoning to upgrade, or until a stable version is published.