### PR TITLE
feat(Grants): Implement Nodl Grants on ZkSync

### DIFF
--- a/src/Grants.sol
+++ b/src/Grants.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.23;
+
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract VestingContract {
+    using SafeERC20 for IERC20;
+
+    struct VestingSchedule {
+        address from;
+        uint256 start;
+        uint256 period;
+        uint32 periodCount;
+        uint256 perPeriodAmount;
+    }
+
+    uint32 public constant MAX_SCHEDULES = 100;
+
+    IERC20 public token;
+    mapping(address => VestingSchedule[]) public vestingSchedules;
+    mapping(address => mapping(address => bool)) public renounces;
+
+    event VestingScheduleAdded(address indexed to, VestingSchedule schedule);
+    event Claimed(address indexed who, uint256 amount);
+    event VestingSchedulesCanceled(address indexed from, address indexed to);
+    event Renounced(address indexed from, address indexed to);
+
+    error InvalidZeroParameter();
+    error InsufficientBalanceToLock();
+    error EmptyVestingSchedules();
+    error VestingToSelf();
+    error MaxSchedulesReached();
+    error RenouncedCancel();
+
+    constructor(address _token) {
+        token = IERC20(_token);
+    }
+
+    function addVestingSchedule(address to, uint256 start, uint256 period, uint32 periodCount, uint256 perPeriodAmount)
+        external
+    {
+        _mustBeNonZero(period);
+        _mustBeNonZero(periodCount);
+        _mustNotCrossMaxSchedules(to);
+
+        token.safeTransferFrom(msg.sender, address(this), perPeriodAmount * periodCount);
+
+        VestingSchedule memory schedule = VestingSchedule(msg.sender, start, period, periodCount, perPeriodAmount);
+        vestingSchedules[to].push(schedule);
+
+        emit VestingScheduleAdded(to, schedule);
+    }
+
+    function claim() external {
+        uint256 totalClaimable = 0;
+        uint256 currentTime = block.timestamp;
+
+        VestingSchedule[] storage schedules = vestingSchedules[msg.sender];
+        for (uint256 i = 0; i < schedules.length; i++) {
+            VestingSchedule storage schedule = schedules[i];
+            if (currentTime > schedule.start) {
+                uint256 periodsElapsed = (currentTime - schedule.start) / schedule.period;
+                uint256 effectivePeriods = periodsElapsed > schedule.periodCount ? schedule.periodCount : periodsElapsed;
+                uint256 claimable = effectivePeriods * schedule.perPeriodAmount;
+                schedule.periodCount -= uint32(effectivePeriods);
+                schedule.start += periodsElapsed * schedule.period;
+                totalClaimable += claimable;
+                if (schedule.periodCount == 0) {
+                    schedules[i] = schedules[schedules.length - 1];
+                    schedules.pop();
+                    i--;
+                }
+            }
+        }
+
+        if (totalClaimable > 0) {
+            token.safeTransferFrom(address(this), msg.sender, totalClaimable);
+        }
+        emit Claimed(msg.sender, totalClaimable);
+    }
+
+    function renounce(address to) external {
+        renounces[to][msg.sender] = true;
+        emit Renounced(msg.sender, to);
+    }
+
+    function cancelVestingSchedules(address to) external {
+        _mustNotBeRenounced(msg.sender, to);
+
+        uint256 totalClaimable = 0;
+        uint256 totalRedeemable = 0;
+        uint256 currentTime = block.timestamp;
+
+        VestingSchedule[] storage schedules = vestingSchedules[to];
+        for (uint256 i = 0; i < schedules.length; i++) {
+            VestingSchedule storage schedule = schedules[i];
+            if (schedule.from == msg.sender) {
+                uint256 periodsElapsed = (currentTime - schedule.start) / schedule.period;
+                uint256 effectivePeriods = periodsElapsed > schedule.periodCount ? schedule.periodCount : periodsElapsed;
+                uint256 claimable = effectivePeriods * schedule.perPeriodAmount;
+                uint256 redeemable = (schedule.periodCount - effectivePeriods) * schedule.perPeriodAmount;
+                totalClaimable += claimable;
+                totalRedeemable += redeemable;
+                schedules[i] = schedules[schedules.length - 1];
+                schedules.pop();
+                i--;
+            }
+        }
+
+        if (totalClaimable > 0) {
+            token.safeTransferFrom(address(this), to, totalClaimable);
+        }
+
+        if (totalRedeemable > 0) {
+            token.safeTransferFrom(address(this), msg.sender, totalRedeemable);
+        }
+
+        emit VestingSchedulesCanceled(msg.sender, to);
+    }
+
+    function _mustBeNonZero(uint256 value) private pure {
+        if (value == 0) {
+            revert InvalidZeroParameter();
+        }
+    }
+
+    function _mustNotCrossMaxSchedules(address to) private view {
+        if (vestingSchedules[to].length >= MAX_SCHEDULES) {
+            revert MaxSchedulesReached();
+        }
+    }
+
+    function _mustNotBeRenounced(address from, address to) private view {
+        if (renounces[to][from]) {
+            revert RenouncedCancel();
+        }
+    }
+}

--- a/src/Grants.sol
+++ b/src/Grants.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract VestingContract {
+contract Grants {
     using SafeERC20 for IERC20;
 
     struct VestingSchedule {
@@ -56,8 +56,9 @@ contract VestingContract {
         uint256 totalClaimable = 0;
         uint256 currentTime = block.timestamp;
 
+        uint256 i = 0;
         VestingSchedule[] storage schedules = vestingSchedules[msg.sender];
-        for (uint256 i = 0; i < schedules.length; i++) {
+        while (i < schedules.length) {
             VestingSchedule storage schedule = schedules[i];
             if (currentTime > schedule.start) {
                 uint256 periodsElapsed = (currentTime - schedule.start) / schedule.period;
@@ -69,13 +70,14 @@ contract VestingContract {
                 if (schedule.periodCount == 0) {
                     schedules[i] = schedules[schedules.length - 1];
                     schedules.pop();
-                    i--;
+                    continue;
                 }
             }
+            i++;
         }
 
         if (totalClaimable > 0) {
-            token.safeTransferFrom(address(this), msg.sender, totalClaimable);
+            token.safeTransfer(msg.sender, totalClaimable);
         }
         emit Claimed(msg.sender, totalClaimable);
     }
@@ -92,11 +94,13 @@ contract VestingContract {
         uint256 totalRedeemable = 0;
         uint256 currentTime = block.timestamp;
 
+        uint256 i = 0;
         VestingSchedule[] storage schedules = vestingSchedules[to];
-        for (uint256 i = 0; i < schedules.length; i++) {
+        while (i < schedules.length) {
             VestingSchedule storage schedule = schedules[i];
             if (schedule.from == msg.sender) {
-                uint256 periodsElapsed = (currentTime - schedule.start) / schedule.period;
+                uint256 periodsElapsed =
+                    currentTime > schedule.start ? (currentTime - schedule.start) / schedule.period : 0;
                 uint256 effectivePeriods = periodsElapsed > schedule.periodCount ? schedule.periodCount : periodsElapsed;
                 uint256 claimable = effectivePeriods * schedule.perPeriodAmount;
                 uint256 redeemable = (schedule.periodCount - effectivePeriods) * schedule.perPeriodAmount;
@@ -104,19 +108,24 @@ contract VestingContract {
                 totalRedeemable += redeemable;
                 schedules[i] = schedules[schedules.length - 1];
                 schedules.pop();
-                i--;
+                continue;
             }
+            i++;
         }
 
         if (totalClaimable > 0) {
-            token.safeTransferFrom(address(this), to, totalClaimable);
+            token.safeTransfer(to, totalClaimable);
         }
 
         if (totalRedeemable > 0) {
-            token.safeTransferFrom(address(this), msg.sender, totalRedeemable);
+            token.safeTransfer(msg.sender, totalRedeemable);
         }
 
         emit VestingSchedulesCanceled(msg.sender, to);
+    }
+
+    function getGrantsCount(address to) external view returns (uint256) {
+        return vestingSchedules[to].length;
     }
 
     function _mustBeNonZero(uint256 value) private pure {

--- a/src/Grants.sol
+++ b/src/Grants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.23;
 
 import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity 0.8.23;
 
 import {NODL} from "./NODL.sol";

--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.23;
 
 import {NODL} from "./NODL.sol";

--- a/test/Grants.t.sol
+++ b/test/Grants.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";

--- a/test/Grants.t.sol
+++ b/test/Grants.t.sol
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import "../src/Grants.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("MockToken", "MTK") {
+        _mint(msg.sender, 1000000);
+    }
+}
+
+contract GrantsTest is Test {
+    Grants public grants;
+    MockToken public token;
+    address public alice;
+    address public bob;
+    address public charlie;
+
+    function setUp() public {
+        token = new MockToken();
+        grants = new Grants(address(token));
+        alice = address(0x1);
+        bob = address(0x2);
+        charlie = address(0x3);
+        token.transfer(alice, 10000);
+        token.transfer(charlie, 10000);
+    }
+
+    function test_addVestingSchedule() public {
+        vm.startPrank(alice);
+        token.approve(address(grants), 1000);
+        grants.addVestingSchedule(bob, block.timestamp + 1 days, 2 days, 4, 100);
+        grants.addVestingSchedule(bob, block.timestamp + 3 days, 7 days, 3, 200);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        token.approve(address(grants), 700);
+        grants.addVestingSchedule(bob, block.timestamp + 5 days, 1 days, 2, 350);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(address(grants)), 1700);
+
+        checkSchedule(bob, 0, alice, block.timestamp + 1 days, 2 days, 4, 100);
+        checkSchedule(bob, 1, alice, block.timestamp + 3 days, 7 days, 3, 200);
+        checkSchedule(bob, 2, charlie, block.timestamp + 5 days, 1 days, 2, 350);
+
+        emit log("Test Add Vesting Schedule Passed!");
+    }
+
+    function test_nothingToClaimBeforeStart() public {
+        vm.startPrank(alice);
+        token.approve(address(grants), 400);
+        grants.addVestingSchedule(bob, block.timestamp + 1 days, 2 days, 4, 100);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 0);
+        checkSchedule(bob, 0, alice, block.timestamp + 1 days, 2 days, 4, 100);
+        emit log("Test Nothing to Claim Before Start Passed!");
+    }
+
+    function test_nothingToClaimBeforeOnePeriod() public {
+        vm.startPrank(alice);
+        token.approve(address(grants), 400);
+        grants.addVestingSchedule(bob, block.timestamp + 1 days, 2 days, 4, 100);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 2 days);
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 0);
+        checkSchedule(bob, 0, alice, block.timestamp + 1 days, 2 days, 4, 100);
+        emit log("Test Nothing to Claim Before One Period!");
+    }
+
+    function test_claimAfterOnePeriod() public {
+        uint256 start = block.timestamp + 1 days;
+        uint256 period = 2 days;
+        uint256 nextStart = start + period;
+        vm.startPrank(alice);
+        token.approve(address(grants), 400);
+        grants.addVestingSchedule(bob, start, period, 4, 100);
+        vm.stopPrank();
+
+        vm.warp(nextStart + 1 days);
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 100);
+        checkSchedule(bob, 0, alice, nextStart, 2 days, 3, 100);
+        emit log("Test Claim After One Period!");
+    }
+
+    function test_claimSeveralGrants() public {
+        uint256 start = block.timestamp + 1 days;
+        vm.startPrank(alice);
+        token.approve(address(grants), 1600);
+        grants.addVestingSchedule(bob, start, 2 days, 6, 100);
+        grants.addVestingSchedule(bob, start + 1 days, 3 days, 5, 200);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        token.approve(address(grants), 1200);
+        grants.addVestingSchedule(bob, start + 2 days, 7 days, 4, 300);
+        vm.stopPrank();
+
+        vm.warp(start + 10 days);
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 1400);
+        checkSchedule(bob, 0, alice, block.timestamp, 2 days, 1, 100);
+        checkSchedule(bob, 1, alice, block.timestamp, 3 days, 2, 200);
+        checkSchedule(bob, 2, charlie, block.timestamp - 1 days, 7 days, 3, 300);
+
+        emit log("Test Add Vesting Schedule Passed!");
+    }
+
+    function test_claimRemovesFullyVestedSchedules() public {
+        uint256 start = block.timestamp + 1 days;
+        vm.startPrank(alice);
+        token.approve(address(grants), 600);
+        grants.addVestingSchedule(bob, start, 2 days, 3, 100);
+        grants.addVestingSchedule(bob, start + 10 days, 3 days, 2, 100);
+        vm.stopPrank();
+
+        assertEq(grants.getGrantsCount(bob), 2);
+
+        vm.warp(start + 8 days);
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(grants.getGrantsCount(bob), 1);
+
+        checkSchedule(bob, 0, alice, start + 10 days, 3 days, 2, 100);
+        emit log("Test Claim Removes Fully Vested Schedules Passed!");
+    }
+
+    function test_claimRemovesAllSchedules() public {
+        uint256 start = block.timestamp + 1 days;
+        vm.startPrank(alice);
+        token.approve(address(grants), 500);
+        grants.addVestingSchedule(bob, start, 2 days, 3, 100);
+        grants.addVestingSchedule(bob, start + 10 days, 3 days, 2, 100);
+        vm.stopPrank();
+
+        assertEq(grants.getGrantsCount(bob), 2);
+
+        vm.warp(start + 20 days);
+
+        vm.startPrank(bob);
+        grants.claim();
+        vm.stopPrank();
+
+        assertEq(grants.getGrantsCount(bob), 0);
+
+        emit log("Test Claim Removes All Schedules Passed!");
+    }
+
+    function test_RenounceUpdatesState() public {
+        vm.startPrank(alice);
+        grants.renounce(bob);
+        vm.stopPrank();
+        assertTrue(grants.renounces(bob, alice));
+        assertFalse(grants.renounces(bob, charlie));
+        emit log("Test Renounce Passed!");
+    }
+
+    function test_CancelVestingSchedulesRedeemsAllIfNoneVested() public {
+        uint256 start = block.timestamp;
+        uint256 aliceBalance = token.balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        token.approve(address(grants), 1600);
+
+        grants.addVestingSchedule(bob, start + 2 days, 2 days, 6, 100);
+        grants.addVestingSchedule(bob, start + 3 days, 3 days, 5, 200);
+
+        vm.warp(start + 3 days);
+
+        grants.cancelVestingSchedules(bob);
+
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 0);
+        assertEq(grants.getGrantsCount(bob), 0);
+        assertEq(token.balanceOf(alice), aliceBalance);
+        emit log("Test Cancel Vesting Schedules Redeems All Passed!");
+    }
+
+    function test_CancelVestingSchedulesRedeemsPartiallyVested() public {
+        uint256 start = block.timestamp;
+        uint256 aliceBalance = token.balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        token.approve(address(grants), 1600);
+
+        grants.addVestingSchedule(bob, start + 2 days, 2 days, 6, 100);
+        grants.addVestingSchedule(bob, start + 3 days, 3 days, 5, 200);
+
+        vm.warp(start + 5 days);
+
+        grants.cancelVestingSchedules(bob);
+
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 100);
+        assertEq(grants.getGrantsCount(bob), 0);
+        assertEq(token.balanceOf(alice), aliceBalance - 100);
+        emit log("Test Cancel Vesting Schedules Redeems Partially Vested Passed!");
+    }
+
+    function test_CancelVestingSchedulesRedeemsZeroIfFullyVested() public {
+        uint256 start = block.timestamp;
+        uint256 aliceBalance = token.balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        token.approve(address(grants), 1300);
+
+        grants.addVestingSchedule(bob, start + 2 days, 2 days, 3, 100);
+        grants.addVestingSchedule(bob, start + 3 days, 3 days, 5, 200);
+
+        vm.warp(start + 20 days);
+
+        grants.cancelVestingSchedules(bob);
+
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(bob), 1300);
+        assertEq(grants.getGrantsCount(bob), 0);
+        assertEq(token.balanceOf(alice), aliceBalance - 1300);
+        emit log("Test Cancel Vesting Schedules Redeems Zero Passed!");
+    }
+
+    function test_aliceCanOnlyCancelHerOwnGivenGrants() public {
+        vm.startPrank(alice);
+        token.approve(address(grants), 1000);
+        grants.addVestingSchedule(bob, block.timestamp + 1 days, 2 days, 4, 100);
+        grants.addVestingSchedule(bob, block.timestamp + 3 days, 7 days, 3, 200);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        token.approve(address(grants), 700);
+        grants.addVestingSchedule(bob, block.timestamp + 5 days, 1 days, 2, 350);
+        vm.stopPrank();
+
+        assertEq(grants.getGrantsCount(bob), 3);
+
+        vm.startPrank(alice);
+        grants.cancelVestingSchedules(bob);
+        vm.stopPrank();
+        assertEq(grants.getGrantsCount(bob), 1);
+        checkSchedule(bob, 0, charlie, block.timestamp + 5 days, 1 days, 2, 350);
+    }
+
+    function test_renouncedCannotBeCanceled() public {
+        vm.startPrank(alice);
+        token.approve(address(grants), 1000);
+        grants.addVestingSchedule(bob, block.timestamp + 1 days, 2 days, 4, 100);
+        grants.addVestingSchedule(bob, block.timestamp + 3 days, 7 days, 3, 200);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        token.approve(address(grants), 700);
+        grants.addVestingSchedule(bob, block.timestamp + 5 days, 1 days, 2, 350);
+        vm.stopPrank();
+
+        vm.startPrank(alice);
+        grants.renounce(bob);
+        vm.stopPrank();
+
+        vm.startPrank(alice);
+        vm.expectRevert(Grants.RenouncedCancel.selector);
+        grants.cancelVestingSchedules(bob);
+        vm.stopPrank();
+        assertEq(grants.getGrantsCount(bob), 3);
+
+        vm.startPrank(charlie);
+        grants.cancelVestingSchedules(bob);
+        vm.stopPrank();
+        assertEq(grants.getGrantsCount(bob), 2);
+    }
+
+    function checkSchedule(
+        address beneficiary,
+        uint256 index,
+        address expectedFrom,
+        uint256 expectedStart,
+        uint256 expectedPeriod,
+        uint32 expectedPeriodCount,
+        uint256 expectedPerPeriodAmount
+    ) internal {
+        (address from, uint256 start, uint256 period, uint32 periodCount, uint256 perPeriodAmount) =
+            grants.vestingSchedules(beneficiary, index);
+        assertEq(from, expectedFrom);
+        assertEq(start, expectedStart);
+        assertEq(period, expectedPeriod);
+        assertEq(periodCount, expectedPeriodCount);
+        assertEq(perPeriodAmount, expectedPerPeriodAmount);
+    }
+}

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity 0.8.23;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
Implement this contract to present similar but improved logic compared with pallet-grants on Eden parachain. Here is a couple of differences:

1. No admin or high level access is required. In pallet-grants the governance could cancel grants for anyone (not renounced) but this was too much unwarranted power. This contract allows any vesters to cancel their unvested grants if they have not renounced this authority towards a specific address.
2. Instead of unfriendly block numbers, here we use time stamps.
3. This contract would work with any standard Erc20 token and not just Nodl.

- [x] Add more tests to cover all the errors and events.
- [x] Add docs