### PR TITLE
fix(Rewards): fix digesting arrays as typed data

### DIFF
--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -368,9 +368,8 @@ contract Rewards is AccessControl, EIP712 {
      * @return The digest of the BatchReward struct.
      */
     function digestBatchReward(BatchReward memory batch) public view returns (bytes32) {
-        bytes32 receipentsHash = keccak256(abi.encodePacked(batch.recipients));
-        bytes32 amountsHash = keccak256(abi.encodePacked(batch.amounts));
-        return
-            _hashTypedDataV4(keccak256(abi.encode(BATCH_REWARD_TYPE_HASH, receipentsHash, amountsHash, batch.sequence)));
+        return _hashTypedDataV4(
+            keccak256(abi.encode(BATCH_REWARD_TYPE_HASH, batch.recipients, batch.amounts, batch.sequence))
+        );
     }
 }


### PR DESCRIPTION
The following vague expression in https://eips.ethereum.org/EIPS/eip-712 about how arrays should be digested led us to misinterpretation:

> The array values are encoded as the keccak256 hash of the concatenated encodeData of their contents (i.e. the encoding of SomeType[5] is identical to that of a struct containing five members of type SomeType).

However testing with the Go library for creating such off-chain signed typed data, we now have a better understanding of how such fields should be digested to work properly with other 3rd party libraries. 

@trsmarc can you please test this change with your backend?