### PR TITLE
feat(Rewards): remember the latest batch digest

### DIFF
--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -383,7 +383,7 @@ contract Rewards is AccessControl, EIP712 {
      * @dev Returns the latest batch details.
      * @return The next batch sequence and the latest digest of a successfully submitted batch which must have been for batchSequence - 1.
      */
-    function getLatestBatchDetails() external view returns (uint256, bytes32) {
+    function latestBatchDetails() external view returns (uint256, bytes32) {
         return (batchSequence, latestBatchRewardDigest);
     }
 }

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -122,6 +122,10 @@ contract RewardsTest is Test {
         assertEq(rewards.sequences(recipients[0]), 0);
         assertEq(rewards.sequences(recipients[1]), 0);
         assertEq(rewards.batchSequence(), 1);
+
+        (uint256 currentSeq, bytes32 batchHash) = rewards.latestBatchDetails();
+        assertEq(currentSeq, 1);
+        assertEq(batchHash, rewards.digestBatchReward(rewardsBatch));
     }
 
     function test_gasUsed() public {
@@ -284,6 +288,10 @@ contract RewardsTest is Test {
 
         vm.expectRevert();
         rewards.mintBatchReward(Rewards.BatchReward(recipients, amounts, 0), signature);
+
+        (uint256 currentSeq, bytes32 batchHash) = rewards.latestBatchDetails();
+        assertEq(currentSeq, 0);
+        assertEq(batchHash, bytes32(0));
     }
 
     function test_rewardsClaimedResetsOnNewPeriod() public {


### PR DESCRIPTION
This is needed for our backend to easily enquire which of the issued batch rewards got on chain successfully

- [x] Add tests