### PR TITLE
feat: separate deployer and admin roles

### DIFF
--- a/script/DeployClick.s.sol
+++ b/script/DeployClick.s.sol
@@ -22,7 +22,7 @@ contract DeployClick is Script {
     function run() public {
         vm.startBroadcast();
 
-        WhitelistPaymaster paymaster = new WhitelistPaymaster(withdrawer);
+        WhitelistPaymaster paymaster = new WhitelistPaymaster(whitelistAdmin, withdrawer);
         ClickContentSign nft = new ClickContentSign("ContentSign", "SIGNED", paymaster);
 
         address[] memory whitelist = new address[](1);

--- a/script/DeployContentSignEnterprise.s.sol
+++ b/script/DeployContentSignEnterprise.s.sol
@@ -10,16 +10,18 @@ import {EnterpriseContentSign} from "../src/contentsign/EnterpriseContentSign.so
 contract DeployContentSignEnterprise is Script {
     string internal name;
     string internal symbol;
+    address internal nodlTokenAdmin;
 
     function setUp() public {
         name = vm.envString("N_NAME");
         symbol = vm.envString("N_SYMBOL");
+        nodlTokenAdmin = vm.envAddress("N_NODL_TOKEN_ADMIN");
     }
 
     function run() public {
         vm.startBroadcast();
 
-        EnterpriseContentSign nft = new EnterpriseContentSign(name, symbol);
+        EnterpriseContentSign nft = new EnterpriseContentSign(name, symbol, nodlTokenAdmin);
 
         vm.stopBroadcast();
 

--- a/script/DeployNodlMigration.sol
+++ b/script/DeployNodlMigration.sol
@@ -9,9 +9,10 @@ import {NODLMigration} from "../src/bridge/NODLMigration.sol";
 
 contract DeployNodlMigration is Script {
     address[] internal voters;
-    address internal withdrawer;
+    address internal nodlTokenAdmin;
 
     function setUp() public {
+        nodlTokenAdmin = vm.envAddress("N_NODL_TOKEN_ADMIN");
         voters = new address[](3);
 
         voters[0] = vm.envAddress("N_VOTER1_ADDR");
@@ -22,7 +23,7 @@ contract DeployNodlMigration is Script {
     function run() public {
         vm.startBroadcast();
 
-        NODL nodl = new NODL();
+        NODL nodl = new NODL(nodlTokenAdmin);
         address nodlAddress = address(nodl);
 
         NODLMigration nodlMigration = new NODLMigration(voters, nodl, 2, 3);

--- a/script/DeployRewards.sol
+++ b/script/DeployRewards.sol
@@ -9,6 +9,7 @@ import {Rewards} from "../src/Rewards.sol";
 
 contract DeployRewards is Script {
     address internal nodlAddress;
+    address internal nodlTokenAdmin;
     address internal oracleAddress;
     uint256 internal rewardQuotaPerPeriod;
     uint256 internal rewardPeriod;
@@ -20,18 +21,21 @@ contract DeployRewards is Script {
         rewardQuotaPerPeriod = vm.envUint("N_REWARDS_QUOTA");
         rewardPeriod = vm.envUint("N_REWARDS_PERIOD");
         batchSubmitterIncentive = uint8(vm.envUint("N_REWARDS_SUBMITTER_INCENTIVE"));
+        nodlTokenAdmin = vm.envAddress("N_NODL_TOKEN_ADMIN");
     }
 
     function run() public {
         vm.startBroadcast();
         if (nodlAddress == address(0)) {
-            NODL token = new NODL();
+            NODL token = new NODL(nodlTokenAdmin);
             nodlAddress = address(token);
             console.log("Deployed NODL at %s", nodlAddress);
         }
 
         NODL nodl = NODL(nodlAddress);
-        Rewards rewards = new Rewards(nodl, rewardQuotaPerPeriod, rewardPeriod, oracleAddress, batchSubmitterIncentive);
+        Rewards rewards = new Rewards(
+            nodl, rewardQuotaPerPeriod, rewardPeriod, oracleAddress, batchSubmitterIncentive, nodlTokenAdmin
+        );
         address rewardsAddress = address(rewards);
         nodl.grantRole(nodl.MINTER_ROLE(), rewardsAddress);
 

--- a/src/NODL.sol
+++ b/src/NODL.sol
@@ -9,9 +9,9 @@ import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessContr
 contract NODL is ERC20Burnable, AccessControl {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
-    constructor() ERC20("Nodle Token", "NODL") {
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(MINTER_ROLE, msg.sender);
+    constructor(address admin) ERC20("Nodle Token", "NODL") {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(MINTER_ROLE, admin);
     }
 
     function mint(address to, uint256 amount) public {

--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -160,10 +160,16 @@ contract Rewards is AccessControl, EIP712 {
      * @param initialQuota Initial reward quota.
      * @param initialPeriod Initial reward period.
      * @param oracleAddress Address of the authorized oracle.
+     * @param admin Address of the admin who can change parameters like quota, period and submitter's reward percentage.
      */
-    constructor(NODL token, uint256 initialQuota, uint256 initialPeriod, address oracleAddress, uint8 rewardPercentage)
-        EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION)
-    {
+    constructor(
+        NODL token,
+        uint256 initialQuota,
+        uint256 initialPeriod,
+        address oracleAddress,
+        uint8 rewardPercentage,
+        address admin
+    ) EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION) {
         // This is to avoid the ongoinb overhead of safe math operations
         if (initialPeriod == 0) {
             revert ZeroPeriod();
@@ -175,7 +181,7 @@ contract Rewards is AccessControl, EIP712 {
 
         _mustBeLessThan100(rewardPercentage);
 
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
         nodl = token;
         quota = initialQuota;

--- a/src/contentsign/EnterpriseContentSign.sol
+++ b/src/contentsign/EnterpriseContentSign.sol
@@ -10,8 +10,8 @@ import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessContr
 contract EnterpriseContentSign is BaseContentSign, AccessControl {
     bytes32 public constant WHITELISTED_ROLE = keccak256("WHITELISTED_ROLE");
 
-    constructor(string memory name, string memory symbol) BaseContentSign(name, symbol) {
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    constructor(string memory name, string memory symbol, address admin) BaseContentSign(name, symbol) {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
     function supportsInterface(bytes4 interfaceId)

--- a/src/paymasters/WhitelistPaymaster.sol
+++ b/src/paymasters/WhitelistPaymaster.sol
@@ -14,8 +14,8 @@ contract WhitelistPaymaster is BasePaymaster {
     error UserIsNotWhitelisted();
     error DestIsNotWhitelisted();
 
-    constructor(address withdrawer) BasePaymaster(msg.sender, withdrawer) {
-        _grantRole(WHITELIST_ADMIN_ROLE, msg.sender);
+    constructor(address admin, address withdrawer) BasePaymaster(admin, withdrawer) {
+        _grantRole(WHITELIST_ADMIN_ROLE, admin);
     }
 
     function addWhitelistedContracts(address[] calldata whitelistedContracts) external {

--- a/test/NODL.t.sol
+++ b/test/NODL.t.sol
@@ -13,8 +13,7 @@ contract NODLTest is Test {
     address internal bob = vm.addr(2);
 
     function setUp() public {
-        vm.prank(alice);
-        nodl = new NODL();
+        nodl = new NODL(alice);
     }
 
     function test_defaultACLs() public view {

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -23,8 +23,8 @@ contract RewardsTest is Test {
         oraclePrivateKey = 0xBEEF;
         address oracle = vm.addr(oraclePrivateKey);
 
-        nodlToken = new NODL();
-        rewards = new Rewards(nodlToken, 1000, RENEWAL_PERIOD, oracle, 2);
+        nodlToken = new NODL(address(this));
+        rewards = new Rewards(nodlToken, 1000, RENEWAL_PERIOD, oracle, 2, address(this));
         // Grant MINTER_ROLE to the Rewards contract
         nodlToken.grantRole(nodlToken.MINTER_ROLE(), address(rewards));
     }
@@ -396,7 +396,7 @@ contract RewardsTest is Test {
 
     function test_deployRewardsWithInvalidSubmitterRewardPercentage() public {
         vm.expectRevert(Rewards.OutOfRangeValue.selector);
-        new Rewards(nodlToken, 1000, RENEWAL_PERIOD, vm.addr(1), 101);
+        new Rewards(nodlToken, 1000, RENEWAL_PERIOD, vm.addr(1), 101, address(this));
     }
 
     function test_changingSubmitterRewardPercentageIsEffective() public {

--- a/test/bridge/GrantsMigration.t.sol
+++ b/test/bridge/GrantsMigration.t.sol
@@ -19,7 +19,7 @@ contract GrantsMigrationTest is Test {
     uint256 amount = 0;
 
     function setUp() public {
-        nodl = new NODL();
+        nodl = new NODL(address(this));
         grants = new Grants(address(nodl), 19, 100);
         migration = new GrantsMigration(oracles, nodl, grants, 2, delay);
 

--- a/test/bridge/MigrationNFT.t.sol
+++ b/test/bridge/MigrationNFT.t.sol
@@ -44,7 +44,7 @@ contract MigrationNFTTest is Test {
     uint256[] levels = [500, 1000, 5000, 10000, 100000];
 
     function setUp() public {
-        nodl = new NODL();
+        nodl = new NODL(address(this));
         migration = new NODLMigration(oracles, nodl, 1, 0);
         migrationNFT = new MigrationNFT(migration, maxHolders, levels, levelToTokenURI);
 

--- a/test/bridge/NODLMigration.t.sol
+++ b/test/bridge/NODLMigration.t.sol
@@ -16,7 +16,7 @@ contract NODLMigrationTest is Test {
     address user = vm.addr(4);
 
     function setUp() public {
-        nodl = new NODL();
+        nodl = new NODL(address(this));
         migration = new NODLMigration(oracles, nodl, 2, delay);
 
         nodl.grantRole(nodl.MINTER_ROLE(), address(migration));

--- a/test/contentsign/ClickContentSign.t.sol
+++ b/test/contentsign/ClickContentSign.t.sol
@@ -15,8 +15,7 @@ contract ClickContentSignTest is Test {
     address internal bob = vm.addr(2);
 
     function setUp() public {
-        vm.prank(alice);
-        paymaster = new WhitelistPaymaster(alice);
+        paymaster = new WhitelistPaymaster(alice, alice);
         nft = new ClickContentSign("Name", "Symbol", paymaster);
 
         address[] memory contracts = new address[](1);

--- a/test/contentsign/EnterpriseContentSign.t.sol
+++ b/test/contentsign/EnterpriseContentSign.t.sol
@@ -13,8 +13,8 @@ contract EnterpriseContentSignTest is Test {
     address internal bob = vm.addr(2);
 
     function setUp() public {
+        nft = new EnterpriseContentSign("Name", "Symbol", alice);
         vm.startPrank(alice);
-        nft = new EnterpriseContentSign("Name", "Symbol");
         nft.grantRole(nft.WHITELISTED_ROLE(), bob);
         vm.stopPrank();
     }

--- a/test/paymasters/WhitelistPaymaster.t.sol
+++ b/test/paymasters/WhitelistPaymaster.t.sol
@@ -9,7 +9,7 @@ import {BasePaymaster} from "../../src/paymasters/BasePaymaster.sol";
 import {WhitelistPaymaster} from "../../src/paymasters/WhitelistPaymaster.sol";
 
 contract MockWhitelistPaymaster is WhitelistPaymaster {
-    constructor(address withdrawer) WhitelistPaymaster(withdrawer) {}
+    constructor(address admin, address withdrawer) WhitelistPaymaster(admin, withdrawer) {}
 
     function mock_validateAndPayGeneralFlow(address from, address to, uint256 requiredETH) public view {
         _validateAndPayGeneralFlow(from, to, requiredETH);
@@ -39,8 +39,7 @@ contract WhitelistPaymasterTest is Test {
     address[] internal whitelistTargets;
 
     function setUp() public {
-        vm.prank(alice);
-        paymaster = new MockWhitelistPaymaster(bob);
+        paymaster = new MockWhitelistPaymaster(alice, bob);
 
         whitelistTargets = new address[](1);
         whitelistTargets[0] = charlie;


### PR DESCRIPTION
Assign admin privileges to a designated multi-signature (multi-sig) or governance-controlled address during deployment rather than granting these privileges to the deployer. This approach reduces the risk of a single point of failure associated with the deployer’s private key.