### PR TITLE
feat(Rewards): allow period to be changed by admin

### DIFF
--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -72,7 +72,7 @@ contract Rewards is AccessControl, EIP712 {
     /**
      * @dev Reward quota renewal period.
      */
-    uint256 public immutable period;
+    uint256 public period;
 
     /**
      * @dev Maximum amount of rewards that can be distributed in a period.
@@ -164,15 +164,7 @@ contract Rewards is AccessControl, EIP712 {
     constructor(NODL token, uint256 initialQuota, uint256 initialPeriod, address oracleAddress, uint8 rewardPercentage)
         EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION)
     {
-        // This is to avoid the ongoinb overhead of safe math operations
-        if (initialPeriod == 0) {
-            revert ZeroPeriod();
-        }
-        // This is to prevent overflows while avoiding the ongoing overhead of safe math operations
-        if (initialPeriod > MAX_PERIOD) {
-            revert TooLongPeriod();
-        }
-
+        _mustBeWithinPeriodRange(initialPeriod);
         _mustBeLessThan100(rewardPercentage);
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -193,6 +185,16 @@ contract Rewards is AccessControl, EIP712 {
         _checkRole(DEFAULT_ADMIN_ROLE);
         quota = newQuota;
         emit QuotaSet(newQuota);
+    }
+
+    /**
+     * @dev Sets the reward period. Only accounts with the DEFAULT_ADMIN_ROLE can call this function.
+     * @param newPeriod The new reward period.
+     */
+    function setPeriod(uint256 newPeriod) external {
+        _checkRole(DEFAULT_ADMIN_ROLE);
+        _mustBeWithinPeriodRange(newPeriod);
+        period = newPeriod;
     }
 
     /**
@@ -355,6 +357,21 @@ contract Rewards is AccessControl, EIP712 {
             sum += batch.amounts[i];
         }
         return sum;
+    }
+
+    /**
+     * @dev Internal function to ensure the period is within the acceptable range.
+     * @param newPeriod The new period to be checked.
+     */
+    function _mustBeWithinPeriodRange(uint256 newPeriod) internal {
+        // This is to avoid the ongoing overhead of safe math operations
+        if (newPeriod == 0) {
+            revert ZeroPeriod();
+        }
+        // This is to prevent overflows while avoiding the ongoing overhead of safe math operations
+        if (newPeriod > MAX_PERIOD) {
+            revert TooLongPeriod();
+        }
     }
 
     /**

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -46,6 +46,28 @@ contract RewardsTest is Test {
         assertEq(rewards.quota(), 2000);
     }
 
+    function test_setPeriod() public {
+        assertEq(rewards.period(), RENEWAL_PERIOD);
+        rewards.setPeriod(2 * RENEWAL_PERIOD);
+        assertEq(rewards.period(), 2 * RENEWAL_PERIOD);
+        rewards.setPeriod(RENEWAL_PERIOD);
+    }
+
+    function test_setPeriodOutOfRange() public {
+        vm.expectRevert(Rewards.ZeroPeriod.selector);
+        rewards.setPeriod(0);
+        uint256 tooLongPeriod = rewards.MAX_PERIOD() + 1;
+        vm.expectRevert(Rewards.TooLongPeriod.selector);
+        rewards.setPeriod(tooLongPeriod);
+    }
+
+    function test_setPeriodUnauthorized() public {
+        address bob = address(3);
+        vm.expectRevert_AccessControlUnauthorizedAccount(bob, rewards.DEFAULT_ADMIN_ROLE());
+        vm.prank(bob);
+        rewards.setPeriod(2 * RENEWAL_PERIOD);
+    }
+
     function test_setQuotaUnauthorized() public {
         address bob = address(3);
         vm.expectRevert_AccessControlUnauthorizedAccount(bob, rewards.DEFAULT_ADMIN_ROLE());


### PR DESCRIPTION
Add a setter method similar to the existing setQuota function, allowing the DEFAULT_ADMIN_ROLE user to adjust the period.