### PR TITLE
feat(clk-gateway): prefer 4xx over 5xx when error is parsable

### DIFF
--- a/clk-gateway/src/index.ts
+++ b/clk-gateway/src/index.ts
@@ -125,6 +125,21 @@ app.get(
         owner,
       });
     } catch (error) {
+      if (isParsableError(error)) {
+        const decodedError = CLICK_NAME_SERVICE_INTERFACE.parseError(
+          error.data,
+        );
+        if (decodedError !== null && typeof decodedError.name === "string") {
+          if (decodedError.name === "ERC721NonexistentToken") {
+            res.status(404).send({ error: "Name not found" });
+            return;
+          }
+          if (decodedError.name === "NameExpired") {
+            res.status(410).send({ error: "Name expired" });
+            return;
+          }
+        }
+      }
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       res.status(500).send({ error: errorMessage });

--- a/clk-gateway/src/interfaces.ts
+++ b/clk-gateway/src/interfaces.ts
@@ -44,6 +44,8 @@ export const CLICK_NAME_SERVICE_INTERFACE = new Interface([
   "function expires(uint256 key) public view returns (uint256)",
   "function register(address to, string memory name)",
   "function resolve(string memory name) external view returns (address)",
+  "error NameExpired(address oldOwner, uint256 expiredAt)",
+  "error ERC721NonexistentToken(uint256 tokenId)",
 ]);
 
 // The storage slot of ERC721._owners within the ClickNameService contract


### PR DESCRIPTION
Attempts to decode the smart contract revert reason to return 4xx when possible.