### PR TITLE
Consistent openzeppelin imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 node_modules/
+local/
+clk-gateway/dist/
+.DS_Store
+.env-*
+*.env
 
 # Compiler files
 cache/
@@ -9,7 +14,6 @@ zkout/
 /broadcast
 /broadcast/*/31337/
 /broadcast/**/dry-run/
-
 # Docs
 docs/
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin=lib/openzeppelin-contracts/

--- a/script/DeployMigrationNFT.s.sol
+++ b/script/DeployMigrationNFT.s.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.23;
 
 import {Script, console} from "forge-std/Script.sol";
-import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {MigrationNFT} from "../src/bridge/MigrationNFT.sol";
 import {NODLMigration} from "../src/bridge/NODLMigration.sol";
 

--- a/src/Grants.sol
+++ b/src/Grants.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.23;
 
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title Grants

--- a/src/NODL.sol
+++ b/src/NODL.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.8.23;
 
-import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import {ERC20Burnable} from "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessControl.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
 contract NODL is ERC20Burnable, AccessControl {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");

--- a/src/Payment.sol
+++ b/src/Payment.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.23;
 
 import {QuotaControl} from "./QuotaControl.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title Payment Contract

--- a/src/QuotaControl.sol
+++ b/src/QuotaControl.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity 0.8.23;
 
-import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessControl.sol";
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title QuotaControl
@@ -153,7 +153,7 @@ contract QuotaControl is AccessControl {
      * - The `newPeriod` must be greater than 0.
      * - The `newPeriod` must not exceed `MAX_PERIOD`.
      */
-    function _mustBeWithinPeriodRange(uint256 newPeriod) internal {
+    function _mustBeWithinPeriodRange(uint256 newPeriod) internal pure {
         if (newPeriod == 0) {
             revert ZeroPeriod();
         }

--- a/src/Rewards.sol
+++ b/src/Rewards.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.23;
 
 import {NODL} from "./NODL.sol";
 import {QuotaControl} from "./QuotaControl.sol";
-import {EIP712} from "openzeppelin-contracts/contracts/utils/cryptography/EIP712.sol";
-import {SignatureChecker} from "openzeppelin-contracts/contracts/utils/cryptography/SignatureChecker.sol";
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title Nodle DePIN Rewards

--- a/src/bridge/MigrationNFT.sol
+++ b/src/bridge/MigrationNFT.sol
@@ -22,7 +22,7 @@
  */
 pragma solidity 0.8.23;
 
-import {ERC721} from "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {NODLMigration} from "./NODLMigration.sol";
 
 contract MigrationNFT is ERC721 {

--- a/src/contentsign/BaseContentSign.sol
+++ b/src/contentsign/BaseContentSign.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.8.23;
 
-import {ERC721} from "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
-import {ERC721URIStorage} from "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
 /// @notice a simple NFT contract for contentsign data where each nft is mapped to a one-time
 /// configurable URL. This is used for every variant of ContentSign with associated hooks.

--- a/src/contentsign/EnterpriseContentSign.sol
+++ b/src/contentsign/EnterpriseContentSign.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 
 import {BaseContentSign} from "./BaseContentSign.sol";
 
-import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessControl.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
 /// @notice the content sign contract variant for enterprises. Only users whitelisted on this contract can mint
 contract EnterpriseContentSign is BaseContentSign, AccessControl {

--- a/src/contentsign/PaymentMiddleware.sol
+++ b/src/contentsign/PaymentMiddleware.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.20;
 
 import {BaseContentSign} from "./BaseContentSign.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
-import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentMiddleware is Ownable {
     using SafeERC20 for IERC20;

--- a/src/nameservice/ClickNameService.sol
+++ b/src/nameservice/ClickNameService.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.23;
 
-import {ERC721} from "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
-import {ERC721Burnable} from "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Burnable.sol";
-import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessControl.sol";
-import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Burnable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {IClickNameService} from "./IClickNameService.sol";
 
 /**

--- a/src/nameservice/ClickResolver.sol
+++ b/src/nameservice/ClickResolver.sol
@@ -8,7 +8,7 @@
 pragma solidity ^0.8.23;
 
 import {IERC165} from "lib/forge-std/src/interfaces/IERC165.sol";
-import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {
     StorageProof,
     StorageProofVerifier

--- a/src/paymasters/BasePaymaster.sol
+++ b/src/paymasters/BasePaymaster.sol
@@ -9,7 +9,7 @@ import {
 } from "lib/era-contracts/l2-contracts/contracts/interfaces/IPaymaster.sol";
 import {IPaymasterFlow} from "lib/era-contracts/l2-contracts/contracts/interfaces/IPaymasterFlow.sol";
 import {Transaction} from "lib/era-contracts/l2-contracts/contracts/L2ContractHelper.sol";
-import {AccessControl} from "openzeppelin-contracts/contracts/access/AccessControl.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
 uint160 constant SYSTEM_CONTRACTS_OFFSET = 0x8000;
 address payable constant BOOTLOADER_FORMAL_ADDRESS = payable(address(SYSTEM_CONTRACTS_OFFSET + 0x01));

--- a/test/NODL.t.sol
+++ b/test/NODL.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 
 import {Test, console} from "forge-std/Test.sol";
 import {NODL} from "../src/NODL.sol";
-import {ERC20Capped} from "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Capped.sol";
+import {ERC20Capped} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Capped.sol";
 
 contract NODLTest is Test {
     NODL private nodl;
@@ -21,11 +21,11 @@ contract NODLTest is Test {
         assert(nodl.hasRole(nodl.MINTER_ROLE(), alice));
     }
 
-    function test_has18Decimals() public {
+    function test_has18Decimals() public view {
         assertEq(nodl.decimals(), 18);
     }
 
-    function test_shouldDeployWithNoSupply() public {
+    function test_shouldDeployWithNoSupply() public view {
         assertEq(nodl.totalSupply(), 0);
     }
 

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console.sol";
 import "../src/NODL.sol";
 import "../src/QuotaControl.sol";
 import "../src/Rewards.sol";
-import "openzeppelin-contracts/contracts/utils/cryptography/MessageHashUtils.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import "./__helpers__/AccessControlUtils.sol";
 
 contract RewardsTest is Test {
@@ -256,7 +256,7 @@ contract RewardsTest is Test {
         rewards.mintBatchReward(rewardsBatch, signature);
     }
 
-    function test_digestReward() public {
+    function test_digestReward() public view {
         bytes32 hashedEIP712DomainType =
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
         bytes32 hashedName = keccak256(bytes("rewards.depin.nodle"));

--- a/test/__helpers__/AccessControlUtils.sol
+++ b/test/__helpers__/AccessControlUtils.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
-import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 library AccessControlUtils {
     function expectRevert_AccessControlUnauthorizedAccount(Vm vm, address user, bytes32 role) internal {

--- a/test/bridge/GrantsMigration.t.sol
+++ b/test/bridge/GrantsMigration.t.sol
@@ -58,7 +58,7 @@ contract GrantsMigrationTest is Test {
         nodl.grantRole(nodl.MINTER_ROLE(), address(migration));
     }
 
-    function test_oraclesAreRegisteredProperly() public {
+    function test_oraclesAreRegisteredProperly() public view {
         for (uint256 i = 0; i < oracles.length; i++) {
             assertEq(migration.isOracle(oracles[i]), true);
         }

--- a/test/bridge/MigrationNFT.t.sol
+++ b/test/bridge/MigrationNFT.t.sol
@@ -51,7 +51,7 @@ contract MigrationNFTTest is Test {
         nodl.grantRole(nodl.MINTER_ROLE(), address(migration));
     }
 
-    function test_initialState() public {
+    function test_initialState() public view {
         assertEq(migrationNFT.nextTokenId(), 0);
         assertEq(migrationNFT.maxHolders(), maxHolders);
         assertEq(address(migrationNFT.migration()), address(migration));

--- a/test/bridge/NODLMigration.t.sol
+++ b/test/bridge/NODLMigration.t.sol
@@ -22,7 +22,7 @@ contract NODLMigrationTest is Test {
         nodl.grantRole(nodl.MINTER_ROLE(), address(migration));
     }
 
-    function test_oraclesAreRegisteredProperly() public {
+    function test_oraclesAreRegisteredProperly() public view {
         for (uint256 i = 0; i < oracles.length; i++) {
             assertEq(migration.isOracle(oracles[i]), true);
         }
@@ -30,7 +30,7 @@ contract NODLMigrationTest is Test {
         assertEq(migration.delay(), delay);
     }
 
-    function test_configuredProperToken() public {
+    function test_configuredProperToken() public view {
         assertEq(address(migration.nodl()), address(nodl));
     }
 


### PR DESCRIPTION
Enabling both forge and hardhat builds and addressing some warnings