### PR TITLE
chore: add deploy script for ClickBounty

### DIFF
--- a/deploy/click_bounty.dp.ts
+++ b/deploy/click_bounty.dp.ts
@@ -29,7 +29,7 @@ module.exports = async function (hre: HardhatRuntimeEnvironment) {
   ];
 
   console.log(
-    "Deploying Payment contract with constructor args: ",
+    "Deploying ClickBounty contract with constructor args: ",
     constructorArgs
   );
 

--- a/deploy/click_bounty.dp.ts
+++ b/deploy/click_bounty.dp.ts
@@ -1,0 +1,54 @@
+import { Provider, Wallet } from "zksync-ethers";
+import { Deployer } from "@matterlabs/hardhat-zksync";
+import { ethers } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import "@matterlabs/hardhat-zksync-node/dist/type-extensions";
+import "@matterlabs/hardhat-zksync-verify/dist/src/type-extensions";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+module.exports = async function (hre: HardhatRuntimeEnvironment) {
+  const oracleAddress = process.env.CLICK_BOUNTY_ORACLE_ADDR!;
+  const tokenAddress = process.env.N_TOKEN_ADDR!;
+  const contentSignAddress = process.env.CONTENT_SIGN_ADDR!;
+  const entryFee = process.env.CLICK_BOUNTY_ENTRY!;
+  const adminAddress = process.env.CLICK_BOUNTY_ADMIN_ADDR!;
+
+  const rpcUrl = hre.network.config.url!;
+  const provider = new Provider(rpcUrl);
+  const wallet = new Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
+  const deployer = new Deployer(hre, wallet);
+
+  const constructorArgs = [
+    oracleAddress,
+    tokenAddress,
+    contentSignAddress,
+    entryFee,
+    adminAddress
+  ];
+
+  console.log(
+    "Deploying Payment contract with constructor args: ",
+    constructorArgs
+  );
+
+  const artifact = await deployer.loadArtifact("ClickBounty");
+  const fee = await deployer.estimateDeployFee(
+    artifact,
+    constructorArgs
+  );
+  console.log(
+    "ClickBounty deployment fee (ETH): ",
+    ethers.formatEther(fee)
+  );
+
+  const contract = await deployer.deploy(
+    artifact,
+    constructorArgs
+  );
+  await contract.waitForDeployment();
+  const address = await contract.getAddress();
+  console.log("Deployed ClickBounty contract at", address);
+
+};

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,8 +48,11 @@ const config: HardhatUserConfig = {
         version: "0.8.23",
     },
     paths: {
-        sources: "src",
+        sources: "src",        
     },
+    etherscan: {
+        apiKey: process.env.ETHERSCAN_API_KEY,
+    }
 };
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,7 +48,7 @@ const config: HardhatUserConfig = {
         version: "0.8.23",
     },
     paths: {
-        sources: "src",        
+        sources: "src",
     },
     etherscan: {
         apiKey: process.env.ETHERSCAN_API_KEY,


### PR DESCRIPTION
Also allow hardhat config to have ETHERSCAN_API_KEY to verify contract. This deployment script used to deploy https://sepolia-era.zksync.network/address/0x6aac68102f9096d42aB302cc6b66Dd57CE7b1E79#code