### PR TITLE
Update /storageProof helpers - adapted them to latest changes on root contract

### DIFF
--- a/clk-gateway/src/interfaces.ts
+++ b/clk-gateway/src/interfaces.ts
@@ -4,9 +4,10 @@ import { Interface, toBigInt } from "ethers";
 export const ZKSYNC_DIAMOND_INTERFACE = new Interface([
   `function commitBatchesSharedBridge(
         uint256 _chainId,
-        (uint64,bytes32,uint64,uint256,bytes32,bytes32,uint256,bytes32) lastCommittedBatchData,
-        (uint64,uint64,uint64,bytes32,uint256,bytes32,bytes32,bytes32,bytes,bytes)[] newBatchesData
-    )`,
+        uint256 _processBatchFrom,
+        uint256 _processBatchTo,
+        bytes calldata
+  )`,
   `function l2LogsRootHash(uint256 _batchNumber) external view returns (bytes32)`,
   `function storedBatchHash(uint256) public view returns (bytes32)`,
   `event BlockCommit(uint256 indexed batchNumber, bytes32 indexed batchHash, bytes32 indexed commitment)`,
@@ -53,3 +54,8 @@ export const CLICK_NAME_SERVICE_OWNERS_STORAGE_SLOT = toBigInt(2);
 
 export const STORAGE_PROOF_TYPE =
   "((uint64 batchNumber, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment) metadata, address account, uint256 key, bytes32 value, bytes32[] path, uint64 index)";
+
+export const STORED_BATCH_INFO_ABI_STRING =
+  "tuple(uint64 batchNumber, bytes32 batchHash, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment)";
+export const COMMIT_BATCH_INFO_ABI_STRING =
+  "tuple(uint64 batchNumber, uint64 timestamp, uint64 indexRepeatedStorageChanges, bytes32 newStateRoot, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 bootloaderHeapInitialContentsHash, bytes32 eventsQueueStateHash, bytes systemLogs, bytes operatorDAInput)";


### PR DESCRIPTION
* Added AbiCoder import in helpers.ts.
* Introduced new constants for commit ABI and stored batch in interfaces.ts.
* Improved parseCommitTransaction function to handle transaction errors not found.
* Added validations for the “sender” parameter in the /storageProof path in index.ts.
* Removed unnecessary whitespace in several functions.