### PR TITLE
Refactor the name service contract deployment 

### DIFF
--- a/script/DeployL1Ens.s.sol
+++ b/script/DeployL1Ens.s.sol
@@ -7,7 +7,7 @@ import {
     StorageProofVerifier,
     IZkSyncDiamond
 } from "lib/zksync-storage-proofs/packages/zksync-storage-contracts/src/StorageProofVerifier.sol";
-import {ClickResolver} from "../src/nameservice/ClickResolver.sol";
+import {UniversalResolver} from "../src/nameservice/UniversalResolver.sol";
 
 interface IResolverSetter {
     function setResolver(bytes32 node, address resolver) external;
@@ -42,28 +42,28 @@ contract DeployL1Ens is Script {
             console.log("Using StorageProofVerifier at", spvAddress);
         }
 
-        address clickResolverAddress = vm.envOr("CLICK_RESOLVER_ADDR", address(0));
+        address resolverAddress = vm.envOr("NS_RESOLVER_ADDR", address(0));
 
-        if (clickResolverAddress == address(0)) {
-            console.log("Deploying ClickResolver...");
-            ClickResolver l1Resolver = new ClickResolver(
-                vm.envString("CNS_OFFCHAIN_RESOLVER_URL"),
-                vm.envAddress("CLK_OWNER_ADDR"),
-                vm.envAddress("CNS_ADDR"),
+        if (resolverAddress == address(0)) {
+            console.log("Deploying UniversalResolver...");
+            UniversalResolver l1Resolver = new UniversalResolver(
+                vm.envString("NS_OFFCHAIN_RESOLVER_URL"),
+                vm.envAddress("NS_OWNER_ADDR"),
+                vm.envAddress("NS_ADDR"),
                 StorageProofVerifier(spvAddress)
             );
-            clickResolverAddress = address(l1Resolver);
-            console.log("Deployed ClickResolver at", clickResolverAddress);
+            resolverAddress = address(l1Resolver);
+            console.log("Deployed UniversalResolver at", resolverAddress);
         }
 
-        string memory label = vm.envString("CNS_DOMAIN");
+        string memory label = vm.envString("NS_DOMAIN");
         bytes32 labelHash = keccak256(abi.encodePacked(label));
 
         bytes32 ETH_NODE = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
         bytes32 node = keccak256(abi.encodePacked(ETH_NODE, labelHash));
 
         IResolverSetter resolverSetter = IResolverSetter(vm.envAddress("NAME_WRAPPER_ADDR"));
-        resolverSetter.setResolver(node, clickResolverAddress);
+        resolverSetter.setResolver(node, resolverAddress);
 
         vm.stopBroadcast();
     }

--- a/src/nameservice/UniversalResolver.sol
+++ b/src/nameservice/UniversalResolver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 /**
- * @title ClickResolver for resolving ens subdomains based on names registered on L2
+ * @title UniversalResolver for resolving ens subdomains based on names registered on L2
  * @dev This contract is based on ClaveResolver that can be found in this repository:
  * https://github.com/getclave/zksync-storage-proofs
  */
@@ -20,7 +20,7 @@ interface IExtendedResolver {
     function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory);
 }
 
-contract ClickResolver is IExtendedResolver, IERC165, Ownable {
+contract UniversalResolver is IExtendedResolver, IERC165, Ownable {
     bytes4 private constant _EXTENDED_INTERFACE_ID = 0x9061b923; // ENSIP-10
 
     bytes4 private constant _ADDR_SELECTOR = 0x3b3b57de; // addr(bytes32)
@@ -158,7 +158,7 @@ contract ClickResolver is IExtendedResolver, IERC165, Ownable {
         string[] memory urls = new string[](1);
         urls[0] = url;
 
-        revert OffchainLookup(address(this), urls, callData, ClickResolver.resolveWithProof.selector, extraData);
+        revert OffchainLookup(address(this), urls, callData, UniversalResolver.resolveWithProof.selector, extraData);
     }
 
     /// @notice Callback used by CCIP read compatible clients to verify and parse the response.


### PR DESCRIPTION
* Removed the `SHOULD_DEPLOY` variable and improved the verification of environment variables required for deployment.
* Rename ClickResolver to `UniversalResolver` contract to handle subdomain resolution based on names registered in L2
* Updated resolver addresses in the deployment script to use `NS_RESOLVER_ADDR` instead of `CLICK_RESOLVER_ADDR`.
* Improved deployment logic to check if `CONTRACT_ADDRESS` is defined before proceeding with contract deployment.