### PR TITLE
Address RES-NODL-BRD01

### DIFF
--- a/src/L1Nodl.sol
+++ b/src/L1Nodl.sol
@@ -12,7 +12,13 @@ import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";
 contract L1Nodl is ERC20, ERC20Burnable, AccessControl, ERC20Permit, ERC20Votes {
     bytes32 private constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
+    /// @dev Zero address supplied where non-zero is required.
+    error ZeroAddress();
+
     constructor(address admin, address minter) ERC20("Nodle Token", "NODL") ERC20Permit("Nodle Token") {
+        if (admin == address(0) || minter == address(0)) {
+            revert ZeroAddress();
+        }
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(MINTER_ROLE, minter);
     }

--- a/src/bridge/L1Bridge.sol
+++ b/src/bridge/L1Bridge.sol
@@ -241,7 +241,6 @@ contract L1Bridge is Ownable2Step, Pausable, IL1Bridge {
         if (isWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex]) {
             revert WithdrawalAlreadyFinalized();
         }
-        isWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex] = true;
 
         (address l1Receiver, uint256 amount) = _parseL2WithdrawalMessage(_message);
         L2Message memory l2ToL1Message =
@@ -256,6 +255,9 @@ contract L1Bridge is Ownable2Step, Pausable, IL1Bridge {
         if (!success) {
             revert InvalidProof();
         }
+
+        isWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex] = true;
+
         L1_NODL.mint(l1Receiver, amount);
         emit WithdrawalFinalized(l1Receiver, _l2BatchNumber, _l2MessageIndex, _l2TxNumberInBatch, amount);
     }

--- a/src/bridge/L1Bridge.sol
+++ b/src/bridge/L1Bridge.sol
@@ -101,6 +101,41 @@ contract L1Bridge is Ownable2Step, Pausable, IL1Bridge {
     }
 
     // =============================
+    // View helpers
+    // =============================
+
+    /**
+     * @notice Quotes the ETH required to cover the L2 execution cost for a deposit at the current tx.gasprice.
+     * @dev This is a convenience helper; the actual base cost is a function of the L1 gas price at inclusion time.
+     *      Frontends may prefer {quoteL2BaseCostAtGasPrice} for deterministic quoting.
+     * @param _l2TxGasLimit Maximum L2 gas the enqueued call can consume.
+     * @param _l2TxGasPerPubdataByte Gas per pubdata byte limit for the enqueued call.
+     * @return baseCost The ETH amount that needs to be supplied alongside {deposit}.
+     */
+    function quoteL2BaseCost(uint256 _l2TxGasLimit, uint256 _l2TxGasPerPubdataByte)
+        external
+        view
+        returns (uint256 baseCost)
+    {
+        baseCost = L1_MAILBOX.l2TransactionBaseCost(tx.gasprice, _l2TxGasLimit, _l2TxGasPerPubdataByte);
+    }
+
+    /**
+     * @notice Quotes the ETH required to cover the L2 execution cost for a deposit at a specified L1 gas price.
+     * @param _l1GasPrice The L1 gas price (wei) to use for the quote.
+     * @param _l2TxGasLimit Maximum L2 gas the enqueued call can consume.
+     * @param _l2TxGasPerPubdataByte Gas per pubdata byte limit for the enqueued call.
+     * @return baseCost The ETH amount that needs to be supplied alongside {deposit}.
+     */
+    function quoteL2BaseCostAtGasPrice(uint256 _l1GasPrice, uint256 _l2TxGasLimit, uint256 _l2TxGasPerPubdataByte)
+        external
+        view
+        returns (uint256 baseCost)
+    {
+        baseCost = L1_MAILBOX.l2TransactionBaseCost(_l1GasPrice, _l2TxGasLimit, _l2TxGasPerPubdataByte);
+    }
+
+    // =============================
     // External entrypoints
     // =============================
 

--- a/src/bridge/L1Bridge.sol
+++ b/src/bridge/L1Bridge.sol
@@ -156,6 +156,9 @@ contract L1Bridge is Ownable2Step, Pausable, IL1Bridge {
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) public payable override whenNotPaused returns (bytes32 txHash) {
+        if (_l2Receiver == address(0)) {
+            revert ZeroAddress();
+        }
         if (_amount == 0) {
             revert ZeroAmount();
         }


### PR DESCRIPTION
This pull request introduces important safety and usability improvements to the `L1Nodl` and `L1Bridge` contracts. The main updates include enhanced input validation to prevent zero address errors, new helper functions for quoting L2 execution costs, and a minor fix to the withdrawal finalization process.

The suggestions from Resonance Security audit are mostly taken except for the followings:
* RES-01 “Unbounded ETH Forwarded to Mailbox”: We retain the exact-match ETH forwarding model (no capping/refund) to minimize avoidable failures and align with zkSync BridgeHub’s design, which shifts fee calculation to caller/off-chain code. However, we add helpers to allow integrators pre-compute msg.value without calling Mailbox directly.
* RES-02 Pausing Contracts Block Deposit Finalization: We consider the current functionality which pauses all major interactions with the bridge as the intended behavior. Many other production bridges do block finalization when the bridge is paused. Since for us "pause" is intended only for emergency situations, we can make this more conservative decision.