### PR TITLE
feat(fleet-identity): add version() function for upgrade verification

### DIFF
--- a/src/swarms/FleetIdentityUpgradeable.sol
+++ b/src/swarms/FleetIdentityUpgradeable.sol
@@ -733,6 +733,15 @@ contract FleetIdentityUpgradeable is
     }
 
     // ══════════════════════════════════════════════
+    // Version
+    // ══════════════════════════════════════════════
+
+    /// @notice Returns the contract version for upgrade verification.
+    function version() external pure virtual returns (string memory) {
+        return "1.0.0";
+    }
+
+    // ══════════════════════════════════════════════
     // UUPS Authorization
     // ══════════════════════════════════════════════
 

--- a/test/upgrade-demo/TestUpgradeOnAnvil.s.sol
+++ b/test/upgrade-demo/TestUpgradeOnAnvil.s.sol
@@ -17,7 +17,7 @@ import {SwarmRegistryL1Upgradeable} from "../../src/swarms/SwarmRegistryL1Upgrad
 
 /// @dev Mock V2 that adds version() - inherits from V1 to preserve storage layout
 contract FleetIdentityUpgradeableV2 is FleetIdentityUpgradeable {
-    function version() external pure returns (string memory) {
+    function version() external pure override returns (string memory) {
         return "2.0.0";
     }
 }

--- a/test/upgradeable/UpgradeableContracts.t.sol
+++ b/test/upgradeable/UpgradeableContracts.t.sol
@@ -61,8 +61,8 @@ contract FleetIdentityUpgradeableV2Mock is FleetIdentityUpgradeable {
         fleetMetadata[tokenId] = metadata;
     }
 
-    function version() external pure returns (string memory) {
-        return "V2";
+    function version() external pure override returns (string memory) {
+        return "2.0.0";
     }
 }
 
@@ -259,6 +259,10 @@ contract UpgradeableContractsTest is Test {
         assertEq(fleetIdentity.symbol(), "SFID");
     }
 
+    function test_FleetIdentity_Version() public view {
+        assertEq(fleetIdentity.version(), "1.0.0");
+    }
+
     function test_FleetIdentity_CannotReinitialize() public {
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         fleetIdentity.initialize(attacker, address(bondToken), BASE_BOND, 0);
@@ -289,7 +293,7 @@ contract UpgradeableContractsTest is Test {
 
         // Verify upgrade
         FleetIdentityUpgradeableV2Mock v2 = FleetIdentityUpgradeableV2Mock(fleetIdentityProxy);
-        assertEq(v2.version(), "V2");
+        assertEq(v2.version(), "2.0.0");
         assertGt(v2.v2InitializedAt(), 0);
 
         // Verify old state preserved
@@ -299,6 +303,16 @@ contract UpgradeableContractsTest is Test {
         vm.prank(alice);
         v2.setFleetMetadata(tokenId, "metadata://test");
         assertEq(v2.fleetMetadata(tokenId), "metadata://test");
+    }
+
+    function test_FleetIdentity_VersionChangesAfterUpgrade() public {
+        assertEq(fleetIdentity.version(), "1.0.0");
+
+        FleetIdentityUpgradeableV2Mock v2Impl = new FleetIdentityUpgradeableV2Mock();
+        vm.prank(owner);
+        fleetIdentity.upgradeToAndCall(address(v2Impl), "");
+
+        assertEq(FleetIdentityUpgradeableV2Mock(fleetIdentityProxy).version(), "2.0.0");
     }
 
     function test_FleetIdentity_NonOwnerCannotUpgrade() public {


### PR DESCRIPTION
## Overview
Add a `version()` function to `FleetIdentityUpgradeable` to enable reliable post-upgrade verification.

## Changes
- **Added `version()` function** to `FleetIdentityUpgradeable.sol` returning `"1.0.0"`
  - Marked as `virtual` to allow overriding in upgraded implementations
  - Industry-standard pattern for upgrade verification (used by OpenZeppelin Governor, Safe, Compound)
  
- **Updated test mocks** to override with appropriate versions
  - V2 mock returns `"2.0.0"`
  
- **Added comprehensive tests**
  - `test_FleetIdentity_Version` — verifies base contract returns `"1.0.0"`
  - `test_FleetIdentity_VersionChangesAfterUpgrade` — confirms proxy reflects new version after upgrade

## Testing
All 20 upgrade tests pass, including new version verification tests.

## Upgrade Verification
After deploying a FleetIdentity upgrade, call:
```bash
cast call 0xdd4437A148C828d47B887c11F55e6fE91d06AC4f "version()" --rpc-url "$L2_RPC"
```

The result should match the new implementation's version string, confirming the upgrade is live and executing new code.