### PR TITLE
docs(readme): add manual on-chain grant claim guide

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,7 @@
     "contentsign",
     "matterlabs",
     "zksync",
+    "zkclient",
     "zksolc",
     "Parachain",
     "subql",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,43 @@ N_WHITELIST=0x732e40223f57d7a1dbf340f5c0cc5b363b60428b \
 forge script script/ContentSignWhitelist.s.sol -i 1 --zksync --rpc-url https://sepolia.era.zksync.dev --broadcast
 ```
 
+## Claiming vested grants manually
+
+Vested NODL is held by the [`Grants`](src/Grants.sol) contract. The Nodle client at
+[zkclient.nodle.com](https://zkclient.nodle.com) (the "Grants" tab) is the easiest way to claim, but
+claiming is fully self-service on-chain and needs no app and no off-chain signature — you only need
+the wallet that holds the grant and a small amount of ETH on ZKsync Era for gas. This section shows
+how to claim directly with [`cast`](https://book.getfoundry.sh/cast/).
+
+```shell
+export ETH_RPC_URL=https://mainnet.era.zksync.io
+# Grants contract — confirm the current address against the docs (see "Mainnet Deployments" above)
+export GRANTS=0x5855c486d2381ba41762876f18684951d5902829
+export ME=0xYourGranteeAddress
+
+# How many vesting schedules does your address have, and how many pages they span?
+cast call $GRANTS "getGrantsCount(address)(uint256)" $ME
+cast call $GRANTS "currentPage(address)(uint256)" $ME
+
+# Claim everything that has vested up to now, across all pages.
+# claim(uint256 start, uint256 end) iterates pages [start, end); passing 0, 0 means "all pages".
+cast send -i $GRANTS "claim(uint256,uint256)" 0 0
+```
+
+Notes:
+
+- `claim` transfers only what has vested up to the current block timestamp; you can call it again
+  later as more periods vest. On success it emits `Claimed(address who, uint256 amount, uint256 start, uint256 end)`.
+- If nothing is currently claimable the call reverts with `NoOpIsFailure()`.
+- For large numbers of schedules you can claim a single page range (e.g. `claim 0 1`) to bound gas
+  rather than sweeping every page at once.
+- Prefer a UI? The same `claim` call can be made from the **Write Contract** tab of the verified
+  `Grants` contract on [explorer.zksync.io](https://explorer.zksync.io).
+
+DePIN rewards are different: they are minted via `Rewards.mintReward` against an oracle-signed
+voucher (domain `rewards.depin.nodle`), which is normally submitted for you by the Nodle backend, so
+the self-service path above applies to vested grants rather than reward issuance.
+
 ## Contract verification
 
 > [!CAUTION]


### PR DESCRIPTION
Closes #69.

#69 asks whether a grant can be claimed directly on-chain instead of through the app — and @ETeissonniere confirmed there's no technical limitation. This adds a short guide to the README so that path is documented.

**What it covers**
- Claiming vested NODL with `Grants.claim(uint256 start, uint256 end)` via `cast`, with no app and no off-chain signature.
- The page-range semantics, including the `claim(0, 0)` = "all pages" shortcut, since that isn't obvious from the signature alone.
- The `NoOpIsFailure()` revert when nothing has vested yet, and that `claim` can be re-called as more periods vest.
- A no-CLI alternative via the explorer **Write Contract** tab.
- A clarification that DePIN rewards (`Rewards.mintReward`) are minted against an oracle-signed voucher and so aren't self-claimed the same way — to avoid confusing the two.

Docs-only change. I kept the `Grants` address pointing back to the existing **Mainnet Deployments** section as the source of truth rather than duplicating it as canonical. Happy to relocate this into a `docs/` file instead of the README, or adjust wording, if you'd prefer.

Drafted with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
