### PR TITLE
docs(ops): Sepolia Bridgehub rehearsal & L2 redeploy requirement

### DIFF
--- a/ops/bridgehub-migration-cutover.md
+++ b/ops/bridgehub-migration-cutover.md
@@ -23,16 +23,35 @@ finalized.
 Equally important in the other direction: after cutover the **old bridge must not keep minting**,
 or new withdrawals could be finalized on both instances. Hence the pause/revoke steps below.
 
+## L2 bridge must also be redeployed
+
+`L2Bridge.initialize(address)` is **one-shot** — once `l1Bridge` is set it cannot be repointed.
+Deposits enqueue an L2 call to `finalizeDeposit`, which accepts only the aliased L1 bridge
+address stored at initialization (`onlyL1Bridge`).
+
+**Deploying a new L1Bridge against the existing L2Bridge will not mint on L2.** Mainnet cutover
+must therefore either:
+
+1. **Redeploy L2Bridge** (same NODL token), call `initialize(newL1Bridge)`, and pass the new L2
+   address into the new L1Bridge constructor — this is what the Sepolia rehearsal did; or
+2. Ship a contract change (e.g. `setL1Bridge`) before cutover — not available today.
+
+Withdrawal **proofs** still reference the L2 bridge contract address as message sender; a new L2
+deployment is fine as long as the new L1Bridge constructor points at the new `L2_BRIDGE_ADDR`.
+The `LEGACY_BRIDGE` guard keys off `(batch, index)` finalized on the **old L1** bridge, not the
+L2 address in the proof.
+
 ## Addresses
 
-| Contract | Ethereum mainnet | Sepolia |
-| --- | --- | --- |
-| Bridgehub (`BRIDGEHUB`) | `0x303a465B659cBB0ab36eE643eA362c509EEb5213` | `0x35A54c8C757806eB6820629bc82d90E056394C92` |
-| Era Diamond proxy (`L1_MAILBOX`) | `0x32400084C286CF3E17e7B677ea9583e60a000324` | `0x9A6DE0f62Aa270A8bCB1e2610078650D539B1Ef9` |
-| Era chain id (`L2_CHAIN_ID`) | `324` | `300` |
-| Current L1Bridge (`LEGACY_BRIDGE`) | `0x2D02b651Ea9630351719c8c55210e042e940d69a` | `0xF8244F4Aa72D21B4511CD7989221fF96e7d94b60` |
-| L1 NODL (`L1_NODL`) | `0x6dd0E17ec6fE56c5f58a0Fe2Bb813B9b5cc25990` | `0xE057bF2EAa2A53e8b942Fc9bE327b16088Ac0baC` |
-| L2 Bridge (`L2_BRIDGE`) | `0x2c1B65dA72d5Cf19b41dE6eDcCFB7DD83d1B529E` | `0x62063BfC39e8ab2A4dE8d84B87B14a8051cE7634` |
+| Contract | Ethereum mainnet | Sepolia (legacy) | Sepolia (rehearsal, 2026-07-17) |
+| --- | --- | --- | --- |
+| Bridgehub (`BRIDGEHUB`) | `0x303a465B659cBB0ab36eE643eA362c509EEb5213` | `0x35A54c8C757806eB6820629bc82d90E056394C92` | same |
+| Era Diamond proxy (`L1_MAILBOX`) | `0x32400084C286CF3E17e7B677ea9583e60a000324` | `0x9A6DE0f62Aa270A8bCB1e2610078650D539B1Ef9` | same |
+| Era chain id (`L2_CHAIN_ID`) | `324` | `300` | same |
+| L1Bridge (`LEGACY_BRIDGE`) | `0x2D02b651Ea9630351719c8c55210e042e940d69a` | `0xF8244F4Aa72D21b4511CD7989221fF96E7D94B60` | — |
+| New L1Bridge | — | — | `0xd4676309609543A85ee6d18e8A9Ea385521D01a5` |
+| L1 NODL (`L1_NODL`) | `0x6dd0E17ec6fE56c5f58a0Fe2Bb813B9b5cc25990` | `0xE057bF2EAa2A53e8b942Fc9bE327b16088Ac0baC` | same |
+| L2 Bridge (`L2_BRIDGE`) | `0x2c1B65dA72d5Cf19b41dE6eDcCFB7DD83d1B529E` | `0x62063BfC39e8ab2A4dE8d84B87B14a8051cE7634` | `0xff735c70f33ca4eF1768F527B5f230b76A61A89b` |
 
 ## Pre-deployment validation
 
@@ -55,16 +74,26 @@ or new withdrawals could be finalized on both instances. Hence the pause/revoke 
 ## Sepolia rehearsal
 
 Run the full loop on Sepolia first — it is also the early-warning environment, since zkSync ships
-protocol upgrades to testnet before mainnet:
+protocol upgrades to testnet before mainnet. **Status: passed 2026-07-17** (see
+`ops/sepolia-rehearsal-status.md` if present in your checkout).
 
-1. Deploy via `ops/deploy_L1L2_bridge.sh` with `BRIDGEHUB`, `L2_CHAIN_ID=300` and
-   `LEGACY_BRIDGE` set to the current Sepolia bridge.
-2. Deposit → confirm NODL mints on L2 (this covers the Bridgehub → Diamond → L2 path end to end).
-3. Withdraw on L2 → wait for batch execution → `finalizeWithdrawal` on L1.
-4. Deposit with an absurdly low `_l2TxGasLimit` so the L2 tx fails → `claimFailedDeposit`
-   (this is the one path a fork test cannot exercise, since it needs a real failed-tx proof).
-5. Replay a withdrawal already finalized on the old Sepolia bridge → must revert with
-   `WithdrawalFinalizedOnLegacyBridge`.
+1. **Deploy fresh L2 + L1** via `ops/deploy_L1L2_bridge.sh` with `BRIDGEHUB`, `L2_CHAIN_ID=300`,
+   and `LEGACY_BRIDGE` set to the current Sepolia L1 bridge. Unset/clear `L1_BRIDGE` and `L2_BRIDGE`
+   in `.env` so both are redeployed (reuse existing `L1_NODL` / `NODL` tokens).
+   - L2 deploy on zkSync: skip L1-only contracts that break zkSync compile, e.g.
+     `forge script ... --skip src/swarms/SwarmRegistryL1Upgradeable.sol test`
+   - After L1 deploy: `initialize(newL1Bridge)` on the new L2Bridge.
+2. **Deposit → L2 mint** — approve L1 NODL to the new L1 bridge, deposit with Bridgehub fee.
+3. **Withdraw → finalize** — approve L2 NODL to the new L2 bridge (`burnFrom`), withdraw on L2,
+   wait for batch + proof (`zks_getL2ToL1LogProof`; proof may be available before `ethExecuteTxHash`
+   is populated), `finalizeWithdrawal` on the new L1 bridge.
+4. **Failed deposit → claim** — Bridgehub rejects absurdly low `_l2TxGasLimit` at enqueue
+   (`TxnBodyGasLimitNotEnoughGas`). On Sepolia we forced failure by **pausing L2** before the
+   enqueued `finalizeDeposit` executed, then `claimFailedDeposit` after the failed L2 tx lands in
+   an L1 batch (~2h on Sepolia testnet). Allow time for batch commit before claiming.
+5. **Legacy replay guard** — the old Sepolia bridge had no prior finalized withdrawals, so the
+   rehearsal finalized a fresh withdrawal on the **old** L1 bridge, then replayed the same proof on
+   the new bridge → must revert `WithdrawalFinalizedOnLegacyBridge`.
 6. **When zkSync enforces the deprecation on testnet** (watch the canary), rerun steps 2–3.
    That is the real-world proof the new bridge survives the cutoff — schedule the mainnet
    cutover only after this passes.
@@ -79,19 +108,22 @@ regardless). The ordering below exists to prevent double-finalization of withdra
    - Enumerate old-bridge deposits (`DepositInitiated` events) and confirm every L2 tx executed
      successfully — any that failed should be `claimFailedDeposit`-ed on the old bridge *before*
      cutover, while it still has `MINTER_ROLE`.
-2. **Deploy** the new `L1Bridge` with `LEGACY_BRIDGE=0x2D02b651Ea9630351719c8c55210e042e940d69a`
+2. **Deploy L2Bridge** (new instance, same L2 NODL token), grant `MINTER_ROLE`, then
+   **`initialize(newL1Bridge)`** once the L1 address is known.
+3. **Deploy L1Bridge** with `LEGACY_BRIDGE=0x2D02b651Ea9630351719c8c55210e042e940d69a`,
+   `BRIDGEHUB`, `L2_CHAIN_ID=324`, and `L2_BRIDGE` set to the **new** L2 deployment from step 2
    (the deploy script grants the new bridge `MINTER_ROLE`; the grant transaction is executed by
    the NODL admin Safe `0x55f5E48A1d30d67ac13751b523Ca1b3cB5838AD8`).
-3. **Verify** the deployment: constructor wiring (`BRIDGEHUB`, `L2_CHAIN_ID`, `LEGACY_BRIDGE`),
-   explorer verification, one smoke deposit with a small amount.
-4. **Neutralize the old bridge in the same ops window** (Safe transactions):
+4. **Verify** the deployment: constructor wiring, explorer verification, one smoke deposit with a
+   small amount (L1 approve + Bridgehub fee).
+5. **Neutralize the old bridge in the same ops window** (Safe transactions):
    - `pause()` the old bridge (blocks its `deposit`, `finalizeWithdrawal`, `claimFailedDeposit`);
    - optionally also `revokeRole(MINTER_ROLE, oldBridge)` on L1 NODL for defense in depth.
    Until this step completes, a withdrawal could be finalized on **both** instances — keep the
-   gap between steps 2 and 4 as short as possible, and do not announce the new bridge until
-   step 4 is done.
-5. **Repoint** the frontend/app and any off-chain services to the new bridge address.
-6. **Post-checks**: new-bridge deposit mints on L2; a fresh L2 withdrawal finalizes on the new
+   gap between steps 3 and 5 as short as possible, and do not announce the new bridge until
+   step 5 is done.
+6. **Repoint** the frontend/app and any off-chain services to the new L1 and L2 bridge addresses.
+7. **Post-checks**: new-bridge deposit mints on L2; a fresh L2 withdrawal finalizes on the new
    bridge; replaying an old finalized withdrawal reverts with `WithdrawalFinalizedOnLegacyBridge`.
 
 ### In-flight withdrawals
@@ -99,6 +131,10 @@ regardless). The ordering below exists to prevent double-finalization of withdra
 Withdrawals initiated on L2 before the cutover but not yet finalized are **not stuck**: they
 finalize on the *new* bridge (the guard only blocks `(batch, index)` pairs the old bridge already
 paid). This is why pausing the old bridge is safe for users.
+
+**Note:** withdrawals initiated on the **old L2** bridge before redeployment carry the old L2
+sender in their inclusion proof. Finalize those on the old L1 bridge before cutover, or accept
+that they require the old L1 instance (still paused for new ops) to complete.
 
 ### Rollback / stragglers
 

--- a/ops/sepolia-rehearsal-status.md
+++ b/ops/sepolia-rehearsal-status.md
@@ -1,0 +1,24 @@
+# Sepolia Bridgehub rehearsal — PASSED
+
+Date: 2026-07-17
+
+## Deployed
+
+| Contract | Address |
+| --- | --- |
+| New L2Bridge | `0xff735c70f33ca4eF1768F527B5f230b76A61A89b` |
+| New L1Bridge | `0xd4676309609543A85ee6d18e8A9Ea385521D01a5` |
+| LEGACY_BRIDGE (old L1) | `0xF8244F4Aa72D21b4511Cd7989221fF96E7D94B60` |
+| BRIDGEHUB | `0x35A54c8C757806eB6820629bc82d90E056394C92` |
+| L2_CHAIN_ID | `300` |
+
+## Checklist
+
+| Step | Result | Evidence |
+| --- | --- | --- |
+| Deposit → L2 mint | ✅ | L1 `0x143d61e548736bb26594f23dd6eabe4f93811c990e21a0bf5ede505fd478cd75` / L2 `0xc79f882950e1559730eeacdd32e4fd367ceb9ff3c917cd1b701a10ce4cff2663` |
+| Withdraw → finalizeWithdrawal | ✅ | L2 `0x8e953c1c88e51424fd8f79abca5390e22d24b85b3a81d911726dbfb2aefd265f` → L1 `0xb8f8401cd17c070aebb5851ad055d9405d4c6b2b2d0e8dcaaaa9e8798dcc4de9` |
+| Failed deposit → claimFailedDeposit | ✅ | Failed L2 `0x4ad1afbc54f6bbfa0cb7b17883faf93cdd18726a47d18cb0f9d8e2a954a5cea4` → claim L1 `0x76bd1b95fd9b97d541250fedbdef0d1525ee23c623d34f4b04c0d3bfbc888580` |
+| Legacy replay blocked | ✅ | batch `21332` / idx `27` → `WithdrawalFinalizedOnLegacyBridge` |
+
+See `ops/bridgehub-migration-cutover.md` for cutover sequencing updated from this rehearsal.


### PR DESCRIPTION
## Summary

- Record Sepolia rehearsal results (passed 2026-07-17)
- Document L2Bridge redeploy requirement in mainnet cutover sequence
- Update addresses table with rehearsal deployment info
- Add operational notes on deployment steps, failed deposits, and legacy withdrawal guards

## Context

Sepolia rehearsal validated the end-to-end cutover flow: deposit→mint, withdraw→finalize, failed deposit→claim, and legacy withdrawal replay blocking. Critical finding: `L2Bridge.initialize(address)` is one-shot, so mainnet must redeploy L2Bridge alongside L1Bridge.


Made with [Cursor](https://cursor.com)