### PR TITLE
fix(clk-gateway): log unhandled route errors, harden ZyFi failure paths

### DIFF
--- a/clk-gateway/src/helpers.ts
+++ b/clk-gateway/src/helpers.ts
@@ -197,16 +197,50 @@ export async function fetchZyfiSponsored(
   operation = "unknown",
 ): Promise<ZyfiSponsoredResponse> {
   console.log(`ZyFi request [${operation}]: ${JSON.stringify(request)}`);
-  const response = await fetch(zyfiSponsoredUrl!, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-API-KEY": process.env.ZYFI_API_KEY!,
-    },
-    body: JSON.stringify(request),
-  });
 
-  const responseBody = await response.json();
+  // NB: `Response` in this module resolves to Express's type, so infer from fetch.
+  let response: Awaited<ReturnType<typeof fetch>>;
+  try {
+    response = await fetch(zyfiSponsoredUrl!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-KEY": process.env.ZYFI_API_KEY!,
+      },
+      body: JSON.stringify(request),
+    });
+  } catch (error) {
+    // Network-level failure (DNS, TLS, connection reset). The request never
+    // reached ZyFi, so there is no status or body to report.
+    const cause = error instanceof Error ? error.message : String(error);
+    console.error(`ZyFi network failure [${operation}]: ${cause}`);
+    throw new Error(`Failed to reach zyfi sponsored [${operation}]: ${cause}`);
+  }
+
+  // Read as text before parsing: an error emitted by a proxy or load balancer
+  // in front of ZyFi may be HTML or empty, and parsing that as JSON throws a
+  // SyntaxError that discards the status needed to diagnose the failure.
+  const rawBody = await response.text();
+  let responseBody: unknown;
+  try {
+    responseBody = JSON.parse(rawBody);
+  } catch {
+    if (!response.ok) {
+      console.error(
+        `ZyFi error [${operation}] ${response.status} ${response.statusText} (non-JSON body): ${rawBody}`,
+      );
+      throw new Error(
+        `Failed to fetch zyfi sponsored [${operation}]: ${response.status} ${response.statusText} — ${rawBody}`,
+      );
+    }
+    console.error(
+      `ZyFi returned a non-JSON success body [${operation}]: ${rawBody}`,
+    );
+    throw new Error(
+      `Failed to parse zyfi sponsored response [${operation}]: ${rawBody}`,
+    );
+  }
+
   if (!response.ok) {
     console.error(
       `ZyFi error [${operation}] ${response.status} ${response.statusText}:`,

--- a/clk-gateway/src/index.ts
+++ b/clk-gateway/src/index.ts
@@ -518,11 +518,20 @@ app.use('/resolve', resolveRouter);
 
 app.use((err: Error, req: Request, res: Response, next: NextFunction): void => {
   if (err instanceof HttpError) {
+    console.warn(
+      `${req.method} ${req.originalUrl} -> ${err.statusCode}: ${err.message}`
+    );
     res.status(err.statusCode).json({ error: err.message });
     return;
   }
 
   const message = err instanceof Error ? err.message : String(err);
+  // Unexpected failures were previously returned to the client but never
+  // logged, leaving no server-side trace to debug from.
+  console.error(`${req.method} ${req.originalUrl} -> 500: ${message}`);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
   res.status(500).json({ error: message });
 });
 


### PR DESCRIPTION
Rebased onto `main`. Scope narrowed substantially: the original version of this PR duplicated #118, which had already landed. Everything #118 covers has been dropped. What remains is additive only.

## 1. Unhandled route errors are never logged

`src/index.ts` — the global error middleware returns a 500 to the client but never logs:

```ts
const message = err instanceof Error ? err.message : String(err);
res.status(500).json({ error: message });
```

No unexpected error, on **any** route, leaves a server-side trace. Now logs message and stack for 500s, and handled `HttpError`s at warn level with method and URL. #118 did not touch this.

## 2. Network-level failures are indistinguishable from HTTP rejections

A DNS, TLS, or connection-reset failure means the request never reached ZyFi, so there is no status or body to report. Previously this surfaced as an unhelpful generic throw. Now reported explicitly as a network failure.

## 3. `response.json()` ran before the `ok` check

This is a latent gap in #118:

```ts
const responseBody = await response.json();   // <-- before the ok check
if (!response.ok) { ... }
```

If a proxy or load balancer in front of ZyFi returns HTML or an empty body — a 502/504 — `response.json()` throws a `SyntaxError` and the status is discarded, reproducing exactly the blind spot #118 set out to close. The body is now read as text first and parsed after, so the status survives a non-JSON response.

The `operation` label convention from #118 is preserved throughout.

## Verification

- `npx tsc --noEmit` — clean.
- `npx jest` — `routes/names.integration.test.ts` passes (7 tests).
- `src/helpers.test.ts` fails, but **pre-existing and unrelated**: verified it fails identically on a clean checkout. Jest does not load `.env`, so `SERVICE_ACCOUNT_KEY` is undefined and `JSON.parse` throws at import in `src/setup.ts:30`. Left untouched.

Implementation note: in `helpers.ts` the bare type `Response` resolves to *Express's* `Response`, not fetch's, hence `Awaited<ReturnType<typeof fetch>>`.

## Separately — a deployment lead

#118 removed the ``zyfiSponsoredUrl: ${...}`` log from `helpers.ts`. On current `main` the only place that string is still logged is `testPaymaster.ts`, a standalone script. A gateway emitting that line is therefore **not** running post-#118 code — worth checking whether the deployed build predates 2026-07-08.
