### PR TITLE
docs(ops): make the deposit-enumeration pre-check trustworthy

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -171,6 +171,9 @@
     "unstakes",
     "Unstaked",
     "funder",
-    "Fundings"
+    "Fundings",
+    "publicnode",
+    "drpc",
+    "apikey"
   ]
 }

--- a/ops/bridgehub-migration-cutover.md
+++ b/ops/bridgehub-migration-cutover.md
@@ -142,7 +142,7 @@ the deployer EOA holds nothing. The scripts print the required calldata; execute
      bridge deployed at block 23579563, so any full-history scan is an archive request. Free
      public endpoints reject those — but not always as an error you will notice:
 
-     | Endpoint | Behaviour on an archive `eth_getLogs` |
+     | Endpoint | Behavior on an archive `eth_getLogs` |
      | --- | --- |
      | `ethereum-rpc.publicnode.com` | `-32602 Archive requests require a personal token`, which **`cast logs` reports as `[]` with exit 0** |
      | `eth.drpc.org` | serves single requests, then `403` on sustained scanning |

--- a/ops/bridgehub-migration-cutover.md
+++ b/ops/bridgehub-migration-cutover.md
@@ -136,8 +136,35 @@ the deployer EOA holds nothing. The scripts print the required calldata; execute
    - Rerun the fork suite and the canary (above).
    - Enumerate old-bridge deposits (`DepositInitiated` events) and confirm every L2 tx executed
      successfully — any that failed should be `claimFailedDeposit`-ed on the old bridge *before*
-     cutover, while it still has `MINTER_ROLE`. This needs an indexed RPC (Etherscan/Alchemy);
-     a 2M-block `eth_getLogs` range will not complete on a public endpoint.
+     cutover, while it still has `MINTER_ROLE`.
+
+     **This requires an authenticated archive endpoint, and a free one will lie to you.** The
+     bridge deployed at block 23579563, so any full-history scan is an archive request. Free
+     public endpoints reject those — but not always as an error you will notice:
+
+     | Endpoint | Behaviour on an archive `eth_getLogs` |
+     | --- | --- |
+     | `ethereum-rpc.publicnode.com` | `-32602 Archive requests require a personal token`, which **`cast logs` reports as `[]` with exit 0** |
+     | `eth.drpc.org` | serves single requests, then `403` on sustained scanning |
+     | `cloudflare-eth.com`, `rpc.ankr.com/eth`, `eth.merkle.io` | internal error / unauthorized / method not found |
+
+     An empty result here is indistinguishable from "no deposits", and concluding the latter would
+     silently skip refundable failed deposits. Sanity-check any scan against a known-present log
+     before trusting a zero: block 23579563 must return the constructor's `OwnershipTransferred`
+     (`0x8be0079c...`). If it returns nothing, your endpoint is not answering — stop.
+
+     With an Etherscan key:
+
+     ```bash
+     curl -s "https://api.etherscan.io/v2/api?chainid=1&module=logs&action=getLogs\
+&address=0x2D02b651Ea9630351719c8c55210e042e940d69a\
+&topic0=0x5c8b4b222ae9120808577bfefeb97f913b4a7160435dcf81eb32a273dd41ad05\
+&fromBlock=23579563&toBlock=latest&apikey=$ETHERSCAN_API_KEY" | jq '.result | length'
+     ```
+
+     Then for each `l2DepositTxHash` (topic 1), check the L2 status via
+     `zks_getTransactionReceipt` on `https://mainnet.era.zksync.io`; anything failed or missing
+     needs `claimFailedDeposit` on the old bridge before it loses `MINTER_ROLE`.
    - Confirm deployer funding: L1 deployment is ~1.4M gas, so budget **≥0.05 ETH** on L1 for
      headroom against a gas spike mid-cutover, plus ~0.02 ETH on zkSync.
    - Set `BRIDGEHUB`, `L2_CHAIN_ID=324`, `LEGACY_BRIDGE=0x2D02b651Ea9630351719c8c55210e042e940d69a`,


### PR DESCRIPTION
Follow-up to #124. I tried to actually run the deposit-enumeration pre-check and found the guidance I wrote there was wrong — and wrong in the direction that produces a false pass.

## What #124 said

> This needs an indexed RPC (Etherscan/Alchemy); a 2M-block `eth_getLogs` range will not complete on a public endpoint.

Wrong reason. The range completes fine. The actual problem is that the bridge deployed at block 23579563, so any full-history scan is an **archive** request, and free endpoints refuse those — several of them silently.

## What actually happens

| Endpoint | Behaviour on an archive `eth_getLogs` |
| --- | --- |
| `ethereum-rpc.publicnode.com` | `-32602 Archive requests require a personal token` — **`cast logs` reports this as `[]` with exit 0** |
| `eth.drpc.org` | serves single requests, `403` on sustained scanning |
| `cloudflare-eth.com` / `rpc.ankr.com/eth` / `eth.merkle.io` | internal error / unauthorized / method not found |

A scan of the old bridge's full history returned `[]` for `DepositInitiated`. That looks like "no deposits, nothing to claim, safe to cut over." It is not a result at all.

Proof it was a false negative: the deployment receipt at block 23579563 contains an `OwnershipTransferred` log (`0x8be0079c…`) emitted by the `Ownable` constructor, and `eth_getLogs` for that exact single block on the same endpoint returns zero. `isWithdrawalFinalized(503366, 17)` is also `true` on the old bridge, so `WithdrawalFinalized` events demonstrably exist — a full-range query for them likewise returned zero.

## Why it matters

The pre-check exists to catch failed deposits that still need `claimFailedDeposit` while the old bridge holds `MINTER_ROLE`. A silent empty result means skipping them and stranding user refunds — the exact failure the pre-check is meant to prevent, reached by appearing to pass.

## Changes

- Record what each public endpoint actually does
- Give a known-present log (block 23579563 → `0x8be0079c…`) to sanity-check any zero against before trusting it
- Provide a working Etherscan v2 invocation and the `zks_getTransactionReceipt` follow-up for checking L2 status per deposit

## Status

The pre-check itself is **still not done** — it needs a key I don't have. The runbook now makes it runnable in one command and hard to fool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)